### PR TITLE
Gapless playback

### DIFF
--- a/src/providers/Player/index.tsx
+++ b/src/providers/Player/index.tsx
@@ -168,6 +168,30 @@ const PlayerContextInitializer = () => {
 				)
 					useDownload.mutate(nowPlaying!.item)
 
+				// --- GAPLESS PLAYBACK PREFETCH LOGIC ---
+				// If within 10 seconds of end, prefetch next track if not already downloaded
+				if (
+					nowPlaying &&
+					playQueue &&
+					typeof currentIndex === 'number' &&
+					playQueue.length > currentIndex + 1 &&
+					Math.floor(event.duration) - Math.floor(event.position) <= 10
+				) {
+					const nextTrack = playQueue[currentIndex + 1]
+					const isNextDownloaded = downloadedTracks?.some(
+						(download) => download.item.Id === nextTrack.item.Id,
+					)
+					if (
+						!isNextDownloaded &&
+						[networkStatusTypes.ONLINE, undefined, null].includes(
+							networkStatus as networkStatusTypes,
+						) &&
+						autoDownload
+					) {
+						useDownload.mutate(nextTrack.item)
+					}
+				}
+
 				break
 			}
 		}


### PR DESCRIPTION
### What is the change
it prefetches the next track so that playback will be seamless

### What does this address
it auto downloads the next track via our download queue when there's 10 seconds to go in the track, thinking that maybe future interation will be to add a setting to adjust this number?

### Issue number / link
#67 

### Tag reviewers
@anultravioletaurora