### PR TITLE
Add play and shuffle functionality to Album, Artist, and Playlist scr…

### DIFF
--- a/src/components/Album/index.tsx
+++ b/src/components/Album/index.tsx
@@ -20,6 +20,9 @@ import Icon from '../Global/components/icon'
 import { mapDtoToTrack } from '../../helpers/mappings'
 import { useNetworkContext } from '../../providers/Network'
 import { useSettingsContext } from '../../providers/Settings'
+import { useQueueContext } from '../../providers/Player/queue'
+import { usePlayerContext } from '../../providers/Player'
+import { QueuingType } from '../../enums/queuing-type'
 
 /**
  * The screen for an Album's track list
@@ -43,6 +46,8 @@ export function AlbumScreen({ route, navigation }: HomeAlbumProps): React.JSX.El
 		failedDownloads,
 	} = useNetworkContext()
 	const { downloadQuality } = useSettingsContext()
+	const { useLoadNewQueue } = useQueueContext()
+	const { useStartPlayback } = usePlayerContext()
 
 	const { data: discs, isPending } = useQuery({
 		queryKey: [QueryKeys.ItemTracks, album.Id!],
@@ -56,6 +61,28 @@ export function AlbumScreen({ route, navigation }: HomeAlbumProps): React.JSX.El
 		)
 		useDownloadMultiple.mutate(jellifyTracks)
 	}
+
+	const playAlbum = (shuffled: boolean = false) => {
+		if (!discs || discs.length === 0) return
+
+		const allTracks = discs.flatMap((disc) => disc.data)
+		if (allTracks.length === 0) return
+
+		useLoadNewQueue.mutate(
+			{
+				track: allTracks[0],
+				index: 0,
+				tracklist: allTracks,
+				queue: album,
+				queuingType: QueuingType.FromSelection,
+				shuffled,
+			},
+			{
+				onSuccess: () => useStartPlayback.mutate(),
+			},
+		)
+	}
+
 	return (
 		<SectionList
 			contentInsetAdjustmentBehavior='automatic'
@@ -91,7 +118,7 @@ export function AlbumScreen({ route, navigation }: HomeAlbumProps): React.JSX.El
 					</XStack>
 				)
 			}}
-			ListHeaderComponent={() => AlbumTrackListHeader(album, navigation)}
+			ListHeaderComponent={() => AlbumTrackListHeader(album, navigation, playAlbum)}
 			renderItem={({ item: track, index }) => (
 				<Track
 					track={track}
@@ -119,11 +146,13 @@ export function AlbumScreen({ route, navigation }: HomeAlbumProps): React.JSX.El
  * Renders a header for an Album's track list
  * @param album The {@link BaseItemDto} of the album to render the header for
  * @param navigation The navigation object from the parent {@link AlbumScreen}
+ * @param playAlbum The function to call to play the album
  * @returns A React component
  */
 function AlbumTrackListHeader(
 	album: BaseItemDto,
 	navigation: StackNavigationProp<StackParamList>,
+	playAlbum: (shuffled?: boolean) => void,
 ): React.JSX.Element {
 	const { width } = useSafeAreaFrame()
 
@@ -161,12 +190,19 @@ function AlbumTrackListHeader(
 						</YStack>
 					</XStack>
 
-					<XStack justifyContent='center' marginVertical={'$2'}>
+					<XStack
+						justifyContent='center'
+						marginVertical={'$2'}
+						gap={'$4'}
+						flexWrap='wrap'
+					>
 						<FavoriteButton item={album} />
 
-						<Spacer />
-
 						<InstantMixButton item={album} navigation={navigation} />
+
+						<Icon name='play' onPress={() => playAlbum(false)} small />
+
+						<Icon name='shuffle' onPress={() => playAlbum(true)} small />
 					</XStack>
 				</YStack>
 			</XStack>

--- a/src/components/Artist/tab-bar.tsx
+++ b/src/components/Artist/tab-bar.tsx
@@ -13,19 +13,57 @@ import { useJellifyContext } from '../../providers'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { StackParamList } from '../types'
 import React from 'react'
+import Icon from '../Global/components/icon'
+import { useQueueContext } from '../../providers/Player/queue'
+import { usePlayerContext } from '../../providers/Player'
+import { QueuingType } from '../../enums/queuing-type'
+import { fetchAlbumDiscs } from '../../api/queries/item'
 
 export default function ArtistTabBar(
 	props: MaterialTopTabBarProps,
 	stackNavigator: StackNavigationProp<StackParamList>,
 ) {
 	const { api } = useJellifyContext()
-	const { artist, scroll } = useArtistContext()
+	const { artist, scroll, albums } = useArtistContext()
+	const { useLoadNewQueue } = useQueueContext()
+	const { useStartPlayback } = usePlayerContext()
 
 	const { width } = useSafeAreaFrame()
 
 	const theme = useTheme()
 
 	const bannerHeight = getTokens().size['$16'].val
+
+	const playArtist = async (shuffled: boolean = false) => {
+		if (!albums || albums.length === 0) return
+
+		try {
+			// Get all tracks from all albums
+			const albumTracksPromises = albums.map((album) => fetchAlbumDiscs(api, album))
+			const albumDiscs = await Promise.all(albumTracksPromises)
+
+			// Flatten all tracks from all albums
+			const allTracks = albumDiscs.flatMap((discs) => discs.flatMap((disc) => disc.data))
+
+			if (allTracks.length === 0) return
+
+			useLoadNewQueue.mutate(
+				{
+					track: allTracks[0],
+					index: 0,
+					tracklist: allTracks,
+					queue: artist,
+					queuingType: QueuingType.FromSelection,
+					shuffled,
+				},
+				{
+					onSuccess: () => useStartPlayback.mutate(),
+				},
+			)
+		} catch (error) {
+			console.error('Failed to play artist tracks:', error)
+		}
+	}
 
 	const animatedBannerStyle = useAnimatedStyle(() => {
 		'worklet'
@@ -64,8 +102,12 @@ export default function ArtistTabBar(
 					{artist.Name}
 				</H5>
 
-				<XStack justifyContent='flex-end' gap={'$6'}>
+				<XStack justifyContent='flex-end' gap={'$4'} flexWrap='wrap'>
 					<FavoriteButton item={artist} />
+
+					<Icon name='play' onPress={() => playArtist(false)} small />
+
+					<Icon name='shuffle' onPress={() => playArtist(true)} small />
 
 					<InstantMixButton item={artist} navigation={stackNavigator} />
 				</XStack>


### PR DESCRIPTION
This pull request introduces functionality to allow users to play and shuffle albums, artists, and playlists, as well as updates the queue handling logic to support shuffling while maintaining the starting track order. The changes span multiple components and include new methods, UI updates, and enhancements to the queue initialization logic.

### New Playback Features

* **Album Playback and Shuffle**: Added the `playAlbum` function in `AlbumScreen` to enable playing and shuffling albums. Updated the album header to include play and shuffle buttons. (`src/components/Album/index.tsx`) [[1]](diffhunk://#diff-cda38af886f83daed3edd583c67b68f2998d429067246725360610b39bb50dafR64-R85) [[2]](diffhunk://#diff-cda38af886f83daed3edd583c67b68f2998d429067246725360610b39bb50dafL94-R121) [[3]](diffhunk://#diff-cda38af886f83daed3edd583c67b68f2998d429067246725360610b39bb50dafL164-R205)
* **Artist Playback and Shuffle**: Added the `playArtist` function in `ArtistTabBar` to allow playing and shuffling all tracks from an artist's albums. Updated the artist tab bar to include play and shuffle buttons. (`src/components/Artist/tab-bar.tsx`) [[1]](diffhunk://#diff-bd5253f808a0babc8ad3e341d32745ad9fd9efae05fd6aeb55a1c3f2c66919aeR16-R67) [[2]](diffhunk://#diff-bd5253f808a0babc8ad3e341d32745ad9fd9efae05fd6aeb55a1c3f2c66919aeL67-R111)
* **Playlist Playback and Shuffle**: Added the `playPlaylist` function in `PlaylistHeaderControls` to support playing and shuffling playlist tracks. Updated the playlist header controls to include play and shuffle buttons. (`src/components/Playlist/components/header.tsx`) [[1]](diffhunk://#diff-2c793dc6d5bc093be4f0f6864da89e01a172c31bf7d8833aec43710df6047f3eR146-R147) [[2]](diffhunk://#diff-2c793dc6d5bc093be4f0f6864da89e01a172c31bf7d8833aec43710df6047f3eR156-R213)

### Queue Handling Enhancements

* **Shuffling Logic**: Enhanced the `QueueContextInitializer` to support shuffling the queue while keeping the starting track first. Introduced the `shuffleJellifyTracks` utility for shuffling track lists. (`src/providers/Player/queue.tsx`) [[1]](diffhunk://#diff-dfa32a10cc1340e7c985a8626d76561d2d7ad32afa6ad1c647b6a6b5eafec632R22) [[2]](diffhunk://#diff-dfa32a10cc1340e7c985a8626d76561d2d7ad32afa6ad1c647b6a6b5eafec632R267-R322)

### UI Updates

* **Improved Layouts**: Adjusted layouts across album, artist, and playlist components to accommodate new playback controls and improve responsiveness (e.g., added `flexWrap` and adjusted spacing). (`src/components/Album/index.tsx`, `src/components/Artist/tab-bar.tsx`, `src/components/Playlist/components/header.tsx`) [[1]](diffhunk://#diff-cda38af886f83daed3edd583c67b68f2998d429067246725360610b39bb50dafL164-R205) [[2]](diffhunk://#diff-bd5253f808a0babc8ad3e341d32745ad9fd9efae05fd6aeb55a1c3f2c66919aeL67-R111) [[3]](diffhunk://#diff-2c793dc6d5bc093be4f0f6864da89e01a172c31bf7d8833aec43710df6047f3eL105-R113)