### PR TITLE
Fix issue where playback track wasn't updated

### DIFF
--- a/jest/contextual/QueueProvider.test.tsx
+++ b/jest/contextual/QueueProvider.test.tsx
@@ -71,6 +71,7 @@ test(`${QueueProvider.name} renders and functions correctly`, async () => {
 			type: Event.PlaybackActiveTrackChanged,
 			index: 2,
 			track: {
+				url: 'https://example.com/3',
 				item: {
 					Id: '3',
 				},
@@ -88,6 +89,7 @@ test(`${QueueProvider.name} renders and functions correctly`, async () => {
 			type: Event.PlaybackActiveTrackChanged,
 			index: 0,
 			track: {
+				url: 'https://example.com/1',
 				item: {
 					Id: '1',
 				},


### PR DESCRIPTION
### What is the change
Adjusts `loadNewQueue` and `useTrackPlayerEvents` so that playback index is in sync with RNTP

### What does this address
Issue where the playback track being presented wasn't what was being played

### Issue number / link


### Tag reviewers
@anultravioletaurora