### PR TITLE
Add new queries for shuffled, unshuffled queue, and queue reference

### DIFF
--- a/src/providers/Player/constants/queries.ts
+++ b/src/providers/Player/constants/queries.ts
@@ -1,7 +1,16 @@
 import JellifyTrack from '../../../types/JellifyTrack'
 import PlayerQueryKeys from '../enums/queue-keys'
-import { NOW_PLAYING_QUERY_KEY, PLAY_QUEUE_QUERY_KEY, REPEAT_MODE_QUERY_KEY } from './query-keys'
+import {
+	NOW_PLAYING_QUERY_KEY,
+	PLAY_QUEUE_QUERY_KEY,
+	REPEAT_MODE_QUERY_KEY,
+	SHUFFLED_QUERY_KEY,
+	UNSHUFFLED_QUEUE_QUERY_KEY,
+	QUEUE_REF_QUERY_KEY,
+} from './query-keys'
 import TrackPlayer, { Track } from 'react-native-track-player'
+import { queryClient } from '../../../constants/query-client'
+import { Queue } from '../../../player/types/queue-item'
 
 const PLAYER_QUERY_OPTIONS = {
 	enabled: true,
@@ -36,5 +45,32 @@ export const NOW_PLAYING_QUERY = {
 export const REPEAT_MODE_QUERY = {
 	queryKey: REPEAT_MODE_QUERY_KEY,
 	queryFn: TrackPlayer.getRepeatMode,
+	...PLAYER_QUERY_OPTIONS,
+}
+
+// Local-only queries that are managed via setQueryData elsewhere
+export const SHUFFLED_QUERY = {
+	queryKey: SHUFFLED_QUERY_KEY,
+	// Read from cache; default to false when not set
+	queryFn: () => (queryClient.getQueryData(SHUFFLED_QUERY_KEY) as boolean | undefined) ?? false,
+	initialData: false as boolean,
+	...PLAYER_QUERY_OPTIONS,
+}
+
+export const UNSHUFFLED_QUEUE_QUERY = {
+	queryKey: UNSHUFFLED_QUEUE_QUERY_KEY,
+	// Read from cache; default to empty queue
+	queryFn: () =>
+		(queryClient.getQueryData(UNSHUFFLED_QUEUE_QUERY_KEY) as JellifyTrack[] | undefined) ?? [],
+	initialData: [] as JellifyTrack[],
+	...PLAYER_QUERY_OPTIONS,
+}
+
+export const QUEUE_REF_QUERY = {
+	queryKey: QUEUE_REF_QUERY_KEY,
+	// Read from cache; default to 'Recently Played'
+	queryFn: () =>
+		(queryClient.getQueryData(QUEUE_REF_QUERY_KEY) as Queue | undefined) ?? 'Recently Played',
+	initialData: 'Recently Played' as Queue,
 	...PLAYER_QUERY_OPTIONS,
 }

--- a/src/providers/Player/hooks/queries.ts
+++ b/src/providers/Player/hooks/queries.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query'
-import PlayerQueryKeys from '../enums/queue-keys'
 import TrackPlayer, {
 	Progress,
 	State,
@@ -8,12 +7,14 @@ import TrackPlayer, {
 } from 'react-native-track-player'
 import JellifyTrack from '../../../types/JellifyTrack'
 import { Queue } from '../../../player/types/queue-item'
-import { SHUFFLED_QUERY_KEY } from '../constants/query-keys'
 import {
 	CURRENT_INDEX_QUERY,
 	NOW_PLAYING_QUERY,
 	QUEUE_QUERY,
 	REPEAT_MODE_QUERY,
+	SHUFFLED_QUERY,
+	QUEUE_REF_QUERY,
+	UNSHUFFLED_QUEUE_QUERY,
 } from '../constants/queries'
 import usePlayerEngineStore from '../../../stores/player-engine'
 import { PlayerEngine } from '../../../stores/player-engine'
@@ -41,22 +42,11 @@ export const useNowPlaying = () => useQuery(NOW_PLAYING_QUERY)
 
 export const useQueue = () => useQuery(QUEUE_QUERY)
 
-export const useShuffled = () =>
-	useQuery<boolean>({
-		queryKey: SHUFFLED_QUERY_KEY,
-	})
+export const useShuffled = () => useQuery(SHUFFLED_QUERY)
 
-export const useUnshuffledQueue = () =>
-	useQuery<JellifyTrack[]>({
-		queryKey: [PlayerQueryKeys.UnshuffledQueue],
-		...PLAYER_QUERY_OPTIONS,
-	})
+export const useUnshuffledQueue = () => useQuery(UNSHUFFLED_QUEUE_QUERY)
 
-export const useQueueRef = () =>
-	useQuery<Queue>({
-		queryKey: [PlayerQueryKeys.PlayQueueRef],
-		...PLAYER_QUERY_OPTIONS,
-	})
+export const useQueueRef = () => useQuery(QUEUE_REF_QUERY)
 
 export const useRepeatMode = () => useQuery(REPEAT_MODE_QUERY)
 


### PR DESCRIPTION
### What is the change

- Add queryFns for local player queries (`SHUFFLED_QUERY`, `UNSHUFFLED_QUEUE_QUERY`, `QUEUE_REF_QUERY`) with safe `initialData`.
- Centralize these in `src/providers/Player/constants/queries.ts` and update hooks to use them.

### What does this address

- Removes TanStack Query errors about missing `queryFn` for `["PLAYERSHUFFLED"]` and `["PLAYERPlayQueueRef"]`.
- Ensures cache-backed player queries resolve consistently and stops noisy console warnings.

### Issue number / link

- No issue opened. Addresses runtime errors seen in console:
  - `No queryFn was passed... ["PLAYERSHUFFLED"]`
  - `No queryFn was passed... ["PLAYERPlayQueueRef"]`

### Tag reviewers

@anultravioletaurora

