### PR TITLE
bump gesture-handler / fix crash on modal's background tap

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "react-native-device-info": "15.0.2",
         "react-native-drax": "1.1.0",
         "react-native-fs": "2.20.0",
-        "react-native-gesture-handler": "3.0.0",
+        "react-native-gesture-handler": "3.0.2",
         "react-native-google-cast": "4.9.1",
         "react-native-linear-gradient": "2.8.3",
         "react-native-mmkv": "4.3.1",
@@ -2078,7 +2078,7 @@
 
     "react-native-fs": ["react-native-fs@2.20.0", "", { "dependencies": { "base-64": "^0.1.0", "utf8": "^3.0.0" }, "peerDependencies": { "react-native": "*", "react-native-windows": "*" }, "optionalPeers": ["react-native-windows"] }, "sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ=="],
 
-    "react-native-gesture-handler": ["react-native-gesture-handler@3.0.0", "", { "dependencies": { "@types/react-test-renderer": "^19.1.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-6E8o9D2sHwhFGiU0c4aCweMdJwIbQeBV+dq3IQ3HcqKhVGzg7ccEycap6i0zGCtIYfs3V29Xd4OycwcRj5qxBQ=="],
+    "react-native-gesture-handler": ["react-native-gesture-handler@3.0.2", "", { "dependencies": { "@types/react-test-renderer": "^19.1.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-XBTgmvr2jh/xrMwlHTV2Z1x6IFUl3zfLxyaCAnvj3GSXK5YlY3ZmiIs57hniPmh3I7RtjPFxtGdRr0i+PzyBrg=="],
 
     "react-native-google-cast": ["react-native-google-cast@4.9.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/HvIKAaWHtG6aTNCxrNrqA2ftWGkfH0M/2iN+28pdGUXpKmueb33mgL1m8D4zzwEODQMcmpfoCsym1IwDvugBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-native-device-info": "15.0.2",
     "react-native-drax": "1.1.0",
     "react-native-fs": "2.20.0",
-    "react-native-gesture-handler": "3.0.0",
+    "react-native-gesture-handler": "3.0.2",
     "react-native-google-cast": "4.9.1",
     "react-native-linear-gradient": "2.8.3",
     "react-native-mmkv": "4.3.1",


### PR DESCRIPTION
### What is the change
Updated react-native-gesture-handler to 3.0.2 version

### What does this address
fix android crash when tap on the background of formSheet modal
see https://github.com/software-mansion/react-native-gesture-handler/pull/4243

### Issue number / link


### Tag reviewers
@anultravioletaurora