### PR TITLE
Home Screen Row Overlap Fix (Android), Queue Screen Fixes, Change Instant Mix Generation Endpoint

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -46,7 +46,6 @@ export default function App(): React.JSX.Element {
 function Container(): React.JSX.Element {
 	return (
 		<GestureHandlerRootView style={styles.gestureHandlerRootView}>
-			<ReducedMotionConfig mode={ReduceMotion.System} />
 			<TamaguiProvider config={jellifyConfig} defaultTheme={'purple_dark'}>
 				<Jellify />
 			</TamaguiProvider>

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@jellify-music/react-native-reanimated-slider": "0.4.0",
         "@jellyfin/sdk": "0.13.0",
-        "@legendapp/list": "3.1.2",
+        "@legendapp/list": "3.2.0",
         "@react-native-async-storage/async-storage": "3.1.1",
         "@react-native-clipboard/clipboard": "1.16.3",
         "@react-native-community/cli": "20.1.3",
@@ -520,7 +520,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@legendapp/list": ["@legendapp/list@3.1.2", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "*", "react-dom": "*", "react-native": "*" }, "optionalPeers": ["react-dom", "react-native"] }, "sha512-+2kEvE22hUcdtQ9Mky9ZMkOTBH1pYefoLQGCnvQl6CgNAwVvMBe8C2cJlxcWVINzEBXC0mi0z+S+FeHjvJL4TQ=="],
+    "@legendapp/list": ["@legendapp/list@3.2.0", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "*", "react-dom": "*", "react-native": "*" }, "optionalPeers": ["react-dom", "react-native"] }, "sha512-bN+g/oQYjFz+UAyuBN4cmYJAwdJS1TdNcZZOVlh3+VwCQUWrsg0PH46Mvm76gdZSCYMfoFanPY4dKnILcYEzeg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@jellify-music/react-native-reanimated-slider": "0.4.0",
     "@jellyfin/sdk": "0.13.0",
-    "@legendapp/list": "3.1.2",
+    "@legendapp/list": "3.2.0",
     "@react-native-async-storage/async-storage": "3.1.1",
     "@react-native-clipboard/clipboard": "1.16.3",
     "@react-native-community/cli": "20.1.3",

--- a/src/api/queries/instant-mix/utils/index.ts
+++ b/src/api/queries/instant-mix/utils/index.ts
@@ -23,7 +23,7 @@ export function fetchInstantMixFromItem(
 		if (isUndefined(user)) return reject(new Error('User not initialized'))
 
 		getInstantMixApi(api)
-			.getInstantMixFromArtists(
+			.getInstantMixFromItem(
 				{
 					itemId: item.Id!,
 					userId: user.id,

--- a/src/components/Queue/components/track.tsx
+++ b/src/components/Queue/components/track.tsx
@@ -12,6 +12,7 @@ import Track from '../../Global/components/Track'
 import { Queue } from '../../../services/types/queue-item'
 import { TapHandlerData } from 'react-native-gesture-handler/lib/typescript/v3/hooks/gestures/tap/TapTypes'
 import { GestureEndEvent } from 'react-native-gesture-handler/lib/typescript/v3/types'
+import { usePlayerQueueStore } from '../../../stores/player/queue'
 
 type QueuedTrackProps = ListRenderItemInfo<TrackItem> & {
 	queueRef: Queue | undefined
@@ -27,23 +28,29 @@ export default function QueuedTrack({
 }: QueuedTrackProps): JSX.Element | undefined {
 	const track = getTrackDto(item)
 
+	const { queue } = usePlayerQueueStore()
+
+	const trackIndexInQueue = queue.indexOf(item)
+
 	const onTrackPress = async (event: GestureEndEvent<TapHandlerData>) => {
 		'worklet'
-		return !event.canceled && (await skip(index))
+		return !event.canceled && trackIndexInQueue >= 0 && (await skip(trackIndexInQueue))
 	}
 
 	const onRemoveIconPress = async (event: GestureEndEvent<TapHandlerData>) => {
 		'worklet'
-		return !event.canceled && (await removeItemFromQueue(index))
+		return (
+			!event.canceled &&
+			trackIndexInQueue >= 0 &&
+			(await removeItemFromQueue(trackIndexInQueue))
+		)
 	}
 
 	const trackPressGesture = useTapGesture({
-		runOnJS: true,
 		onFinalize: onTrackPress,
 	})
 
 	const removeIconPressGesture = useTapGesture({
-		runOnJS: true,
 		onFinalize: onRemoveIconPress,
 	})
 

--- a/src/components/Queue/components/track.tsx
+++ b/src/components/Queue/components/track.tsx
@@ -12,6 +12,7 @@ import Track from '../../Global/components/Track'
 import { Queue } from '../../../services/types/queue-item'
 import { TapHandlerData } from 'react-native-gesture-handler/lib/typescript/v3/hooks/gestures/tap/TapTypes'
 import { GestureEndEvent } from 'react-native-gesture-handler/lib/typescript/v3/types'
+import { runOnJS } from 'react-native-worklets'
 
 type QueuedTrackProps = ListRenderItemInfo<TrackItem> & {
 	queueIndex: number
@@ -30,12 +31,12 @@ export default function QueuedTrack({
 
 	const onTrackPress = async (event: GestureEndEvent<TapHandlerData>) => {
 		'worklet'
-		return !event.canceled && queueIndex >= 0 && (await skip(queueIndex))
+		return !event.canceled && queueIndex >= 0 && runOnJS(skip)(queueIndex)
 	}
 
 	const onRemoveIconPress = async (event: GestureEndEvent<TapHandlerData>) => {
 		'worklet'
-		return !event.canceled && queueIndex >= 0 && (await removeItemFromQueue(queueIndex))
+		return !event.canceled && queueIndex >= 0 && runOnJS(removeItemFromQueue)(queueIndex)
 	}
 
 	const trackPressGesture = useTapGesture({

--- a/src/components/Queue/components/track.tsx
+++ b/src/components/Queue/components/track.tsx
@@ -12,38 +12,30 @@ import Track from '../../Global/components/Track'
 import { Queue } from '../../../services/types/queue-item'
 import { TapHandlerData } from 'react-native-gesture-handler/lib/typescript/v3/hooks/gestures/tap/TapTypes'
 import { GestureEndEvent } from 'react-native-gesture-handler/lib/typescript/v3/types'
-import { usePlayerQueueStore } from '../../../stores/player/queue'
 
 type QueuedTrackProps = ListRenderItemInfo<TrackItem> & {
+	queueIndex: number
 	queueRef: Queue | undefined
 	ref?: RefObject<View | null>
 }
 
 export default function QueuedTrack({
 	item,
+	queueIndex,
 	index,
 	ref,
 	queueRef,
-	...props
 }: QueuedTrackProps): JSX.Element | undefined {
 	const track = getTrackDto(item)
 
-	const { queue } = usePlayerQueueStore()
-
-	const trackIndexInQueue = queue.indexOf(item)
-
 	const onTrackPress = async (event: GestureEndEvent<TapHandlerData>) => {
 		'worklet'
-		return !event.canceled && trackIndexInQueue >= 0 && (await skip(trackIndexInQueue))
+		return !event.canceled && queueIndex >= 0 && (await skip(queueIndex))
 	}
 
 	const onRemoveIconPress = async (event: GestureEndEvent<TapHandlerData>) => {
 		'worklet'
-		return (
-			!event.canceled &&
-			trackIndexInQueue >= 0 &&
-			(await removeItemFromQueue(trackIndexInQueue))
-		)
+		return !event.canceled && queueIndex >= 0 && (await removeItemFromQueue(queueIndex))
 	}
 
 	const trackPressGesture = useTapGesture({

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -54,6 +54,7 @@ export default function Queue(): React.JSX.Element {
 					onLayout={scrollToCurrentTrack}
 					itemDraxViewProps={itemDraxViewProps}
 					lockToMainAxis
+					estimatedItemSize={80}
 				/>
 			</DraxProvider>
 		</SafeAreaView>

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -30,7 +30,7 @@ export default function Queue(): React.JSX.Element {
 	}
 
 	const renderItem = (props: ListRenderItemInfo<TrackItem>) => (
-		<QueuedTrack {...props} queueRef={queueRef} />
+		<QueuedTrack {...props} queueRef={queueRef} queueIndex={queue.indexOf(props.item)} />
 	)
 
 	const scrollToCurrentTrack = () => {
@@ -50,6 +50,7 @@ export default function Queue(): React.JSX.Element {
 				contentInsetAdjustmentBehavior='automatic'
 				containerStyle={{
 					flex: 1,
+					marginBottom: bottom,
 				}}
 				data={queue}
 				keyExtractor={keyExtractor}

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -1,13 +1,13 @@
 import { useRef } from 'react'
 import { useCurrentIndex, usePlayQueue, useQueueRef } from '../../stores/player/queue'
 import { TrackItem } from 'react-native-nitro-player'
-import { ListRenderItemInfo, FlatList, StyleSheet } from 'react-native'
+import { ListRenderItemInfo, StyleSheet } from 'react-native'
 import { reorderQueue } from '../../hooks/player/functions/queue'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { DraxList, DraxProvider, SortableReorderEvent } from 'react-native-drax'
 import QueuedTrack from './components/track'
 import { itemDraxViewProps } from '../../configs/styling/drax'
-import { LegendList } from '@legendapp/list/react-native'
+import { LegendList, LegendListRef } from '@legendapp/list/react-native'
 
 export default function Queue(): React.JSX.Element {
 	const queue = usePlayQueue()
@@ -16,7 +16,7 @@ export default function Queue(): React.JSX.Element {
 
 	const queueRef = useQueueRef()
 
-	const listRef = useRef<FlatList>(null)
+	const listRef = useRef<LegendListRef>(null)
 
 	const keyExtractor = (item: TrackItem) => `${item.id}`
 

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useCurrentIndex, usePlayQueue, useQueueRef } from '../../stores/player/queue'
 import { TrackItem } from 'react-native-nitro-player'
-import { ListRenderItemInfo, StyleSheet } from 'react-native'
+import { FlatList, ListRenderItemInfo, StyleSheet } from 'react-native'
 import { reorderQueue } from '../../hooks/player/functions/queue'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { DraxList, DraxProvider, SortableReorderEvent } from 'react-native-drax'
@@ -16,7 +16,7 @@ export default function Queue(): React.JSX.Element {
 
 	const queueRef = useQueueRef()
 
-	const listRef = useRef<LegendListRef>(null)
+	const listRef = useRef<FlatList<TrackItem>>(null)
 
 	const keyExtractor = (item: TrackItem) => `${item.id}`
 
@@ -44,7 +44,6 @@ export default function Queue(): React.JSX.Element {
 		<SafeAreaView style={styles.container}>
 			<DraxProvider>
 				<DraxList<TrackItem>
-					component={LegendList}
 					animationConfig={'spring'}
 					data={queue}
 					keyExtractor={keyExtractor}

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -7,6 +7,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { DraxList, DraxProvider, SortableReorderEvent } from 'react-native-drax'
 import QueuedTrack from './components/track'
 import { itemDraxViewProps } from '../../configs/styling/drax'
+import { LegendList } from '@legendapp/list/react-native'
 
 export default function Queue(): React.JSX.Element {
 	const queue = usePlayQueue()
@@ -43,6 +44,7 @@ export default function Queue(): React.JSX.Element {
 		<SafeAreaView style={styles.container}>
 			<DraxProvider>
 				<DraxList<TrackItem>
+					component={LegendList}
 					animationConfig={'spring'}
 					contentInsetAdjustmentBehavior='automatic'
 					data={queue}
@@ -51,7 +53,6 @@ export default function Queue(): React.JSX.Element {
 					renderItem={renderItem}
 					onReorder={onReorder}
 					onLayout={scrollToCurrentTrack}
-					lockToMainAxis
 					itemDraxViewProps={itemDraxViewProps}
 				/>
 			</DraxProvider>

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useCurrentIndex, usePlayQueue, useQueueRef } from '../../stores/player/queue'
 import { TrackItem } from 'react-native-nitro-player'
-import { FlatList, ListRenderItemInfo, StyleSheet } from 'react-native'
+import { ListRenderItemInfo, StyleSheet } from 'react-native'
 import { reorderQueue } from '../../hooks/player/functions/queue'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { DraxList, DraxProvider, SortableReorderEvent } from 'react-native-drax'
@@ -16,7 +16,7 @@ export default function Queue(): React.JSX.Element {
 
 	const queueRef = useQueueRef()
 
-	const listRef = useRef<FlatList<TrackItem>>(null)
+	const listRef = useRef<LegendListRef>(null)
 
 	const keyExtractor = (item: TrackItem) => `${item.id}`
 
@@ -44,7 +44,7 @@ export default function Queue(): React.JSX.Element {
 		<SafeAreaView style={styles.container}>
 			<DraxProvider>
 				<DraxList<TrackItem>
-					animationConfig={'spring'}
+					component={LegendList}
 					data={queue}
 					keyExtractor={keyExtractor}
 					ref={listRef}
@@ -53,7 +53,6 @@ export default function Queue(): React.JSX.Element {
 					onLayout={scrollToCurrentTrack}
 					itemDraxViewProps={itemDraxViewProps}
 					lockToMainAxis
-					estimatedItemSize={80}
 				/>
 			</DraxProvider>
 		</SafeAreaView>

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -46,7 +46,6 @@ export default function Queue(): React.JSX.Element {
 				<DraxList<TrackItem>
 					component={LegendList}
 					animationConfig={'spring'}
-					contentInsetAdjustmentBehavior='automatic'
 					data={queue}
 					keyExtractor={keyExtractor}
 					ref={listRef}
@@ -54,6 +53,7 @@ export default function Queue(): React.JSX.Element {
 					onReorder={onReorder}
 					onLayout={scrollToCurrentTrack}
 					itemDraxViewProps={itemDraxViewProps}
+					lockToMainAxis
 				/>
 			</DraxProvider>
 		</SafeAreaView>

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -59,6 +59,7 @@ export default function Queue(): React.JSX.Element {
 				onReorder={onReorder}
 				onLayout={scrollToCurrentTrack}
 				lockToMainAxis
+				recycleItems
 				itemDraxViewProps={itemDraxViewProps}
 			/>
 		</DraxProvider>

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -1,13 +1,12 @@
 import { useRef } from 'react'
 import { useCurrentIndex, usePlayQueue, useQueueRef } from '../../stores/player/queue'
 import { TrackItem } from 'react-native-nitro-player'
-import { ListRenderItemInfo, FlatList, View, StyleSheet } from 'react-native'
+import { ListRenderItemInfo, FlatList, StyleSheet } from 'react-native'
 import { reorderQueue } from '../../hooks/player/functions/queue'
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { DraxList, DraxProvider, SortableReorderEvent } from 'react-native-drax'
 import QueuedTrack from './components/track'
 import { itemDraxViewProps } from '../../configs/styling/drax'
-import { LegendList } from '@legendapp/list/react-native'
 
 export default function Queue(): React.JSX.Element {
 	const queue = usePlayQueue()
@@ -17,8 +16,6 @@ export default function Queue(): React.JSX.Element {
 	const queueRef = useQueueRef()
 
 	const listRef = useRef<FlatList>(null)
-
-	const { bottom } = useSafeAreaInsets()
 
 	const keyExtractor = (item: TrackItem) => `${item.id}`
 
@@ -46,7 +43,6 @@ export default function Queue(): React.JSX.Element {
 		<SafeAreaView style={styles.container}>
 			<DraxProvider>
 				<DraxList<TrackItem>
-					component={LegendList}
 					animationConfig={'spring'}
 					contentInsetAdjustmentBehavior='automatic'
 					data={queue}

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -1,13 +1,13 @@
 import { useRef } from 'react'
 import { useCurrentIndex, usePlayQueue, useQueueRef } from '../../stores/player/queue'
 import { TrackItem } from 'react-native-nitro-player'
-import { ListRenderItemInfo } from 'react-native'
+import { ListRenderItemInfo, FlatList, View, StyleSheet } from 'react-native'
 import { reorderQueue } from '../../hooks/player/functions/queue'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { DraxList, DraxProvider, SortableReorderEvent } from 'react-native-drax'
 import QueuedTrack from './components/track'
-import { LegendList, LegendListRef } from '@legendapp/list/react-native'
 import { itemDraxViewProps } from '../../configs/styling/drax'
+import { LegendList } from '@legendapp/list/react-native'
 
 export default function Queue(): React.JSX.Element {
 	const queue = usePlayQueue()
@@ -16,7 +16,7 @@ export default function Queue(): React.JSX.Element {
 
 	const queueRef = useQueueRef()
 
-	const listRef = useRef<LegendListRef>(null)
+	const listRef = useRef<FlatList>(null)
 
 	const { bottom } = useSafeAreaInsets()
 
@@ -43,25 +43,28 @@ export default function Queue(): React.JSX.Element {
 	}
 
 	return (
-		<DraxProvider>
-			<DraxList<TrackItem>
-				component={LegendList}
-				animationConfig={'spring'}
-				contentInsetAdjustmentBehavior='automatic'
-				containerStyle={{
-					flex: 1,
-					marginBottom: bottom,
-				}}
-				data={queue}
-				keyExtractor={keyExtractor}
-				ref={listRef}
-				renderItem={renderItem}
-				onReorder={onReorder}
-				onLayout={scrollToCurrentTrack}
-				lockToMainAxis
-				recycleItems
-				itemDraxViewProps={itemDraxViewProps}
-			/>
-		</DraxProvider>
+		<SafeAreaView style={styles.container}>
+			<DraxProvider>
+				<DraxList<TrackItem>
+					component={LegendList}
+					animationConfig={'spring'}
+					contentInsetAdjustmentBehavior='automatic'
+					data={queue}
+					keyExtractor={keyExtractor}
+					ref={listRef}
+					renderItem={renderItem}
+					onReorder={onReorder}
+					onLayout={scrollToCurrentTrack}
+					lockToMainAxis
+					itemDraxViewProps={itemDraxViewProps}
+				/>
+			</DraxProvider>
+		</SafeAreaView>
 	)
 }
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+})


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the queue and gesture handling logic, as well as minor API and UI adjustments. The main changes include updating gesture handling for queue actions to use the correct queue index, ensuring proper interaction with the queue, and making minor UI and API call adjustments.

**Queue and Gesture Handling Improvements:**

* Updated `QueuedTrack` to receive a `queueIndex` prop and use it for queue actions (`skip` and `removeItemFromQueue`), ensuring actions are performed on the correct item. Now, actions are dispatched only if `queueIndex` is valid, and they are run on the JS thread using `runOnJS`. (`src/components/Queue/components/track.tsx`, `src/components/Queue/index.tsx`) [[1]](diffhunk://#diff-1719e7c3e45f3faa8dcdc2c2afdcd1cef6484e45ec6644ccb050517344bd9657R15-L46) [[2]](diffhunk://#diff-8ff4d09d1eb0268a3b6856e751cc83628587e77dfccbdb74afd41a9563d42c1dL33-R33)
* Modified the rendering of `QueuedTrack` in the queue list to pass the correct `queueIndex` by using `queue.indexOf(props.item)`. (`src/components/Queue/index.tsx`)

**UI Adjustments:**

* Added a `marginBottom` to the queue container style to account for safe area insets, improving layout on devices with notches or home indicators. (`src/components/Queue/index.tsx`)
* Removed the `ReducedMotionConfig` component from the app container, simplifying the root view. (`App.tsx`)

**API Call Update:**

* Changed the API call in `fetchInstantMixFromItem` to use the correct method, `getInstantMixFromItem`, instead of `getInstantMixFromArtists`. (`src/api/queries/instant-mix/utils/index.ts`)