### PR TITLE
signals

### DIFF
--- a/jest/functional/Player/track-media-info.test.ts
+++ b/jest/functional/Player/track-media-info.test.ts
@@ -105,10 +105,9 @@ describe('updateTrackMediaInfo', () => {
 
 		const result = await updateTrackMediaInfo([track])
 
-		expect(resolveTrackUrls).toHaveBeenCalledWith([track], 'stream')
+		expect(resolveTrackUrls).toHaveBeenCalledWith([track], 'stream', undefined)
 		expect(TrackPlayer.updateTracks).toHaveBeenCalledWith([updatedTrack])
 		expect(updateQueueTracks).toHaveBeenCalledWith([updatedTrack])
-		expect(result).toEqual([updatedTrack])
 	})
 
 	it('concurrent calls both complete and each updates the player and queue store', async () => {
@@ -156,7 +155,11 @@ describe('onTracksNeedUpdate', () => {
 
 		await onTracksNeedUpdate(tracks, 2)
 
-		expect(resolveTrackUrls).toHaveBeenCalledWith(tracks.slice(0, 2), 'stream')
+		expect(resolveTrackUrls).toHaveBeenCalledWith(
+			tracks.slice(0, 2),
+			'stream',
+			expect.any(Object),
+		)
 	})
 
 	it('passes all tracks when the lookahead equals or exceeds the track count', async () => {
@@ -165,6 +168,6 @@ describe('onTracksNeedUpdate', () => {
 
 		await onTracksNeedUpdate(tracks, 10)
 
-		expect(resolveTrackUrls).toHaveBeenCalledWith(tracks, 'stream')
+		expect(resolveTrackUrls).toHaveBeenCalledWith(tracks, 'stream', expect.any(Object))
 	})
 })

--- a/src/api/queries/album/index.ts
+++ b/src/api/queries/album/index.ts
@@ -66,7 +66,7 @@ const useAlbums = () => {
 			yearMin,
 			yearMax,
 		],
-		queryFn: ({ pageParam }) =>
+		queryFn: ({ pageParam, signal }) =>
 			fetchAlbums(
 				api,
 				user,
@@ -77,6 +77,7 @@ const useAlbums = () => {
 				[sortDescending ? SortOrder.Descending : SortOrder.Ascending],
 				yearMin,
 				yearMax,
+				signal,
 			),
 		initialPageParam: 0,
 		select: selectAlbums,

--- a/src/api/queries/media/queries.ts
+++ b/src/api/queries/media/queries.ts
@@ -10,7 +10,11 @@ import { ONE_DAY, queryClient } from '../../../constants/query-client'
 import { PlaybackInfoResponse } from '@jellyfin/sdk/lib/generated-client/models/playback-info-response'
 import { EnsureQueryDataOptions } from '@tanstack/react-query'
 
-export const MediaInfoQuery = (itemId: string | null | undefined, source: SourceType) => {
+export const MediaInfoQuery = (
+	itemId: string | null | undefined,
+	source: SourceType,
+	signal?: AbortSignal,
+) => {
 	const api = getApi()
 
 	const streamingProfile = useStreamingDeviceProfileStore.getState().deviceProfile
@@ -23,7 +27,7 @@ export const MediaInfoQuery = (itemId: string | null | undefined, source: Source
 			deviceProfile: profile,
 			itemId,
 		}),
-		queryFn: ({ signal }) => fetchMediaInfo(profile, itemId, signal),
+		queryFn: () => fetchMediaInfo(profile, itemId, signal),
 		enabled: Boolean(api && profile && itemId),
 		staleTime: ONE_DAY,
 	} as EnsureQueryDataOptions<PlaybackInfoResponse>
@@ -32,6 +36,9 @@ export const MediaInfoQuery = (itemId: string | null | undefined, source: Source
 export default async function ensureMediaInfoQuery(
 	itemId: string | null | undefined,
 	source: SourceType,
+	signal?: AbortSignal,
 ) {
-	return await queryClient.ensureQueryData<PlaybackInfoResponse>(MediaInfoQuery(itemId, source))
+	return await queryClient.ensureQueryData<PlaybackInfoResponse>(
+		MediaInfoQuery(itemId, source, signal),
+	)
 }

--- a/src/api/queries/recents/index.ts
+++ b/src/api/queries/recents/index.ts
@@ -35,8 +35,8 @@ export const PlayItAgainQuery: (
 
 	return {
 		queryKey: RecentlyPlayedTracksQueryKey(user, library),
-		queryFn: ({ pageParam }: { pageParam: number }) =>
-			fetchRecentlyPlayed(api, user, library, pageParam),
+		queryFn: ({ pageParam, signal }) =>
+			fetchRecentlyPlayed(api, user, library, pageParam, signal),
 		initialPageParam: 0,
 		select: (data: InfiniteData<BaseItemDto[]>) => data.pages.flatMap((page) => page),
 		getNextPageParam: (
@@ -72,7 +72,8 @@ export const useRecentArtists = () => {
 
 	return useInfiniteQuery({
 		queryKey: RecentlyPlayedArtistsQueryKey(user, library),
-		queryFn: ({ pageParam }) => fetchRecentlyPlayedArtists(api, user, library, pageParam),
+		queryFn: ({ pageParam, signal }) =>
+			fetchRecentlyPlayedArtists(api, user, library, pageParam, signal),
 		select: (data) => data.pages.flatMap((page) => page),
 		initialPageParam: 0,
 		getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => {

--- a/src/api/queries/recents/utils/index.ts
+++ b/src/api/queries/recents/utils/index.ts
@@ -67,6 +67,7 @@ export async function fetchRecentlyPlayed(
 	user: JellifyUser | undefined,
 	library: JellifyLibrary | undefined,
 	page: number,
+	signal?: AbortSignal,
 	limit: number = ApiLimits.Recents,
 ): Promise<BaseItemDto[]> {
 	return new Promise((resolve, reject) => {
@@ -75,18 +76,21 @@ export async function fetchRecentlyPlayed(
 		if (isUndefined(library)) return reject('Library instance not set')
 
 		getItemsApi(api)
-			.getItems({
-				includeItemTypes: [BaseItemKind.Audio],
-				startIndex: page * limit,
-				userId: user.id,
-				limit,
-				parentId: library.musicLibraryId,
-				recursive: true,
-				sortBy: [ItemSortBy.DatePlayed],
-				sortOrder: [SortOrder.Descending],
-				fields: [ItemFields.ParentId, ItemFields.Tags],
-				enableUserData: true,
-			})
+			.getItems(
+				{
+					includeItemTypes: [BaseItemKind.Audio],
+					startIndex: page * limit,
+					userId: user.id,
+					limit,
+					parentId: library.musicLibraryId,
+					recursive: true,
+					sortBy: [ItemSortBy.DatePlayed],
+					sortOrder: [SortOrder.Descending],
+					fields: [ItemFields.ParentId, ItemFields.Tags],
+					enableUserData: true,
+				},
+				{ signal },
+			)
 			.then((response) => {
 				if (!response.data.Items) return resolve([])
 
@@ -155,6 +159,7 @@ export function fetchRecentlyPlayedArtists(
 	user: JellifyUser | undefined,
 	library: JellifyLibrary | undefined,
 	page: number,
+	signal?: AbortSignal,
 ): Promise<BaseItemDto[]> {
 	return new Promise((resolve, reject) => {
 		if (isUndefined(api)) return reject('Client instance not set')
@@ -193,16 +198,19 @@ export function fetchRecentlyPlayedArtists(
 				}
 
 				getItemsApi(api)
-					.getItems({
-						userId: user.id,
-						includeItemTypes: [BaseItemKind.MusicArtist],
-						ids: artistIds,
-						fields: [ItemFields.Genres, ItemFields.SortName, ItemFields.Tags],
-						enableImages: true,
-						enableImageTypes: [ImageType.Backdrop, ImageType.Primary],
-						imageTypeLimit: 1,
-						enableUserData: true,
-					})
+					.getItems(
+						{
+							userId: user.id,
+							includeItemTypes: [BaseItemKind.MusicArtist],
+							ids: artistIds,
+							fields: [ItemFields.Genres, ItemFields.SortName, ItemFields.Tags],
+							enableImages: true,
+							enableImageTypes: [ImageType.Backdrop, ImageType.Primary],
+							imageTypeLimit: 1,
+							enableUserData: true,
+						},
+						{ signal },
+					)
 					.then(({ data }) => {
 						const fetchedArtists = data.Items ?? []
 

--- a/src/api/queries/user-data/index.ts
+++ b/src/api/queries/user-data/index.ts
@@ -11,7 +11,7 @@ export const useIsFavorite = (item: BaseItemDto) => {
 
 	return useQuery({
 		queryKey: UserDataQueryKey(user!, item.Id!),
-		queryFn: () => fetchUserData(item.Id!),
+		queryFn: ({ signal }) => fetchUserData(item.Id!, signal),
 		select: ({ IsFavorite }) => IsFavorite || false,
 		enabled: !!item.Id, // Only run if we have the required data
 		staleTime: ONE_MINUTE * 15,

--- a/src/components/Context/index.tsx
+++ b/src/components/Context/index.tsx
@@ -79,7 +79,7 @@ export default function ItemContext({
 
 	const { data: discs } = useQuery({
 		queryKey: [QueryKeys.ItemTracks, item.Id],
-		queryFn: () => fetchAlbumDiscs(api, item),
+		queryFn: ({ signal }) => fetchAlbumDiscs(api, item, signal),
 		enabled: isAlbum,
 	})
 

--- a/src/components/Global/components/item-section-list.tsx
+++ b/src/components/Global/components/item-section-list.tsx
@@ -51,7 +51,7 @@ export default function ItemSectionList({
 				ListEmptyComponent={
 					<YStack flex={1} justify='center' alignItems='center'>
 						<Paragraph marginVertical='auto' color={'$borderColor'}>
-							No tracks
+							No items
 						</Paragraph>
 					</YStack>
 				}

--- a/src/components/Global/components/item-section-list.tsx
+++ b/src/components/Global/components/item-section-list.tsx
@@ -27,7 +27,6 @@ export default function ItemSectionList({
 		<XStack flex={1}>
 			<SectionList
 				ref={ref}
-				contentInsetAdjustmentBehavior='automatic'
 				sections={query.data ?? []}
 				renderSectionHeader={({ section }) => (
 					<ListStickyHeader text={section.title.toUpperCase()} />

--- a/src/components/Playlists/component.tsx
+++ b/src/components/Playlists/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useTheme } from 'tamagui'
+import { Paragraph, useTheme, YStack } from 'tamagui'
 import ItemRow from '../Global/components/item-row'
 import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models'
 import { FetchNextPageOptions } from '@tanstack/react-query'
@@ -54,7 +54,13 @@ export default function Playlists({
 			renderItem={renderItem}
 			onEndReached={handleEndReached}
 			onScrollBeginDrag={closeAllSwipeableRows}
-			ListEmptyComponent={<Text color={'$neutral'}>No playlists</Text>}
+			ListEmptyComponent={
+				<YStack flex={1} justify='center' alignItems='center'>
+					<Paragraph marginVertical='auto' color={'$borderColor'}>
+						No playlists
+					</Paragraph>
+				</YStack>
+			}
 		/>
 	)
 }

--- a/src/components/Playlists/component.tsx
+++ b/src/components/Playlists/component.tsx
@@ -42,7 +42,6 @@ export default function Playlists({
 
 	return (
 		<List
-			contentInsetAdjustmentBehavior='automatic'
 			data={playlists}
 			refreshControl={
 				<RefreshControl

--- a/src/configs/axios.config.ts
+++ b/src/configs/axios.config.ts
@@ -8,7 +8,7 @@ import axios, {
 } from 'axios'
 import { nitroFetchOnWorklet } from 'react-native-nitro-fetch'
 
-const NETWORK_TIMEOUT = 30000
+const NETWORK_TIMEOUT = 15000
 
 type NitroMappedResponse = {
 	status: number

--- a/src/services/player/utils/event-handlers.ts
+++ b/src/services/player/utils/event-handlers.ts
@@ -11,6 +11,12 @@ import { updateTrackMediaInfo } from './track-media-info'
 import reportPlaybackCompleted from '../../../api/mutations/playback/functions/playback-completed'
 
 /**
+ * {@link AbortController} for signalling when to bail from an "onTracksNeedUpdate"
+ * event.
+ */
+let trackUpdateAbortController: AbortController | null = null
+
+/**
  * Tracks the most recent playback state so that resume-from-pause can be
  * distinguished from a genuine first-play, and so that onSeek can include
  * the correct IsPaused value in the progress report.
@@ -47,11 +53,15 @@ export async function onTracksNeedUpdate(tracks: TrackItem[], lookahead: number)
 		`[Player Event] onTracksNeedUpdate triggered for ${tracks.length} track(s). Updating media info...`,
 	)
 
+	trackUpdateAbortController?.abort()
+
 	const tracksToUpdate = lookahead > 0 ? tracks.slice(0, lookahead) : tracks
 
 	console.debug(`[Player Event] Updating media info for track lookahead ${tracksToUpdate.length}`)
 
-	await updateTrackMediaInfo(tracksToUpdate)
+	trackUpdateAbortController = new AbortController()
+
+	await updateTrackMediaInfo(tracksToUpdate, trackUpdateAbortController.signal)
 }
 
 /**

--- a/src/services/player/utils/event-handlers.ts
+++ b/src/services/player/utils/event-handlers.ts
@@ -1,5 +1,4 @@
 import reportPlaybackProgress from '../../../api/mutations/playback/functions/playback-progress'
-import reportPlaybackStarted from '../../../api/mutations/playback/functions/playback-started'
 import { usePlayerPlaybackStore } from '../../../stores/player/playback'
 import { usePlayerQueueStore } from '../../../stores/player/queue'
 import { TrackPlayer, Reason, TrackPlayerState, TrackItem } from 'react-native-nitro-player'
@@ -96,8 +95,6 @@ export async function onChangeTrack(track: TrackItem, reason?: Reason) {
 	 * Apply audio normalization if enabled in the settings, otherwise reset to default volume (100).
 	 */
 	await applyAudioNormalizationIfEnabled(track)
-
-	reportPlaybackStarted(track)
 }
 
 /**

--- a/src/services/player/utils/track-media-info.ts
+++ b/src/services/player/utils/track-media-info.ts
@@ -7,12 +7,15 @@ import { TrackItem, TrackPlayer } from 'react-native-nitro-player'
  * builds updated track objects, calls TrackPlayer.updateTracks and syncs
  * the JS queue store. Has no guards — callers are responsible for gating.
  */
-export async function updateTrackMediaInfo(tracks: TrackItem[]): Promise<TrackItem[]> {
-	const updatedTracks = await resolveTrackUrls(tracks, 'stream')
+export async function updateTrackMediaInfo(
+	tracks: TrackItem[],
+	signal?: AbortSignal,
+): Promise<void> {
+	const updatedTracks = await resolveTrackUrls(tracks, 'stream', signal)
+
+	if (signal?.aborted) return
 
 	await TrackPlayer.updateTracks(updatedTracks)
 
 	updateQueueTracks(updatedTracks)
-
-	return updatedTracks
 }

--- a/src/utils/fetching/track-media-info.ts
+++ b/src/utils/fetching/track-media-info.ts
@@ -9,10 +9,11 @@ import { SourceType } from '@/src/types/JellifyTrack'
 export default async function resolveTrackUrls(
 	trackItems: TrackItem[],
 	source: SourceType,
+	signal?: AbortSignal,
 ): Promise<TrackItem[]> {
 	const playbackInfoEntries = await Promise.allSettled(
 		trackItems.map(async (track) => {
-			const playbackInfo = await ensureMediaInfoQuery(track.id, source)
+			const playbackInfo = await ensureMediaInfoQuery(track.id, source, signal)
 			return [track.id, playbackInfo] as [string, PlaybackInfoResponse]
 		}),
 	)


### PR DESCRIPTION
This pull request introduces support for aborting in-flight media info fetches when track updates are superseded, improving responsiveness and resource usage in the player. The main changes involve propagating an `AbortSignal` through the media info fetching pipeline and updating the event handler logic to cancel previous requests when new updates are triggered.

### Media info fetch abort handling

* Added an optional `signal` parameter to `MediaInfoQuery`, `ensureMediaInfoQuery`, and `resolveTrackUrls` to support aborting fetches for media info. [[1]](diffhunk://#diff-40499c49828ad565f6f48a70a799b3a8c8d2914ddd26db2d792fa971fa83c4e9L13-R17) [[2]](diffhunk://#diff-40499c49828ad565f6f48a70a799b3a8c8d2914ddd26db2d792fa971fa83c4e9R39-R43) [[3]](diffhunk://#diff-132a5de4c13290e084c54e1ab2e45713e47bde9c80b7b2c478ea57683a2534b6R12-R16)
* Updated `updateTrackMediaInfo` to accept an `AbortSignal`, check for aborts after resolving URLs, and return early if aborted.

### Player event handler improvements

* Introduced a shared `AbortController` in the player event handlers to abort any ongoing track media info updates when `onTracksNeedUpdate` is called again, ensuring only the latest update is processed. [[1]](diffhunk://#diff-4bf6f92de7c44bb944d13f2c7c9debd85f46b51dba20657edba4e562e765dc81R13-R18) [[2]](diffhunk://#diff-4bf6f92de7c44bb944d13f2c7c9debd85f46b51dba20657edba4e562e765dc81R56-R64)