### PR TITLE
Fix Recently Added Being Duplicated, Adjust Home Screen Queries

### DIFF
--- a/src/api/queries/recents/index.ts
+++ b/src/api/queries/recents/index.ts
@@ -6,7 +6,7 @@ import {
 	UseInfiniteQueryOptions,
 } from '@tanstack/react-query'
 import { fetchRecentlyPlayed, fetchRecentlyPlayedArtists } from './utils'
-import { ApiLimits } from '../../../configs/query.config'
+import { ApiLimits, MaxPages } from '../../../configs/query.config'
 import { isUndefined } from 'lodash'
 import { useJellifyLibrary } from '../../../stores/auth'
 import { getApi, getUser } from '../../../stores/auth/utils'
@@ -16,7 +16,8 @@ import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client'
 
 const RECENTS_QUERY_CONFIG = {
 	staleTime: ONE_HOUR,
-} as const
+	maxPages: MaxPages.Home,
+}
 
 export const useRecentlyPlayedTracks = () => {
 	const [library] = useJellifyLibrary()

--- a/src/api/queries/recents/utils/index.ts
+++ b/src/api/queries/recents/utils/index.ts
@@ -36,7 +36,7 @@ export async function fetchRecentlyAdded(
 					limit: ApiLimits.Discover,
 					enableUserData: true,
 					fields: [ItemFields.ParentId, ItemFields.Tags],
-					includeItemTypes: [BaseItemKind.Audio, BaseItemKind.MusicAlbum],
+					includeItemTypes: [BaseItemKind.MusicAlbum],
 				},
 				{
 					signal,

--- a/src/configs/axios.config.ts
+++ b/src/configs/axios.config.ts
@@ -8,7 +8,7 @@ import axios, {
 } from 'axios'
 import { nitroFetchOnWorklet } from 'react-native-nitro-fetch'
 
-const NETWORK_TIMEOUT = 15000
+const NETWORK_TIMEOUT = 30_000
 
 type NitroMappedResponse = {
 	status: number

--- a/src/configs/axios.config.ts
+++ b/src/configs/axios.config.ts
@@ -8,7 +8,7 @@ import axios, {
 } from 'axios'
 import { nitroFetchOnWorklet } from 'react-native-nitro-fetch'
 
-const NETWORK_TIMEOUT = 30_000
+const NETWORK_TIMEOUT = 15_000
 
 type NitroMappedResponse = {
 	status: number

--- a/src/configs/query.config.ts
+++ b/src/configs/query.config.ts
@@ -3,6 +3,7 @@ import { ImageFormat } from '@jellyfin/sdk/lib/generated-client/models'
 export const MAX_RETRY_ATTEMPTS = 2
 
 export enum MaxPages {
+	Home = 2,
 	Library = 5,
 }
 


### PR DESCRIPTION
This pull request introduces several improvements to the way recent items are fetched and queried, along with some minor code style and configuration enhancements. The main changes include limiting the types of items fetched for recently added content, introducing a new `MaxPages.Home` configuration, and updating query options to use this new limit.

**Recent items query improvements:**

* The `fetchRecentlyAdded` function now only includes `MusicAlbum` items, excluding `Audio` items, to better control the type of content fetched for recently added queries.

**Configuration enhancements:**

* Introduced a new `MaxPages.Home` value in the `MaxPages` enum within `query.config.ts` to provide a specific page limit for home queries.
* Updated the `RECENTS_QUERY_CONFIG` in `recents/index.ts` to use `maxPages: MaxPages.Home`, ensuring home recent queries are properly limited.
* Added `MaxPages` to the imports in `recents/index.ts` to support the new configuration.

**Code style improvements:**

* Changed the `NETWORK_TIMEOUT` value in `axios.config.ts` to use a more readable underscore-separated number format (`15_000`).