### PR TITLE
Fix queue reordering on play next with existing track

### DIFF
--- a/src/hooks/player/functions/queue.ts
+++ b/src/hooks/player/functions/queue.ts
@@ -101,6 +101,8 @@ async function loadQueue({
 export const playNextInQueue = async ({ tracks }: AddToQueueMutation) => {
 	const { currentIndex, queue } = usePlayerQueueStore.getState()
 
+	const queuedIds = queue.map((track) => track.id)
+
 	/**
 	 * Calculate the insert index for the new tracks.
 	 *
@@ -128,8 +130,33 @@ export const playNextInQueue = async ({ tracks }: AddToQueueMutation) => {
 		return
 	}
 
-	// Add tracks to the same playlist context
-	await PlayerQueue.addTracksToPlaylist(playlistId, newTracks, insertIndex)
+	const tracksToReorder: TrackItem[] = []
+	const tracksToAdd: TrackItem[] = []
+
+	newTracks.forEach((track) => {
+		if (queuedIds.includes(track.id)) {
+			tracksToReorder.push(track)
+		} else {
+			tracksToAdd.push(track)
+		}
+	})
+
+	// Reorder existing tracks to the next position
+	if (tracksToReorder.length > 0) {
+		const reorderPromises = tracksToReorder.map((track, index) =>
+			PlayerQueue.reorderTrackInPlaylist(
+				playlistId,
+				track.id,
+				(currentIndex ?? 0) + index + 1,
+			),
+		)
+		await Promise.all(reorderPromises)
+	}
+
+	// Add new tracks to the queue
+	if (tracksToAdd.length > 0) {
+		await PlayerQueue.addTracksToPlaylist(playlistId, tracksToAdd, insertIndex)
+	}
 
 	// Get the active queue and update Zustand while isQueuing=true blocks callbacks
 	const updatedQueue = await TrackPlayer.getActualQueue()
@@ -169,11 +196,17 @@ export const addToQueue = async (variables: AddToQueueMutation) => {
 	try {
 		const actualQueue = await TrackPlayer.getActualQueue()
 		const actualQueueIds = actualQueue.map((t) => t.id)
-		const tracksToAdd = variables.tracks.filter((item) => !actualQueueIds.includes(item.Id!))
 
-		if (variables.queuingType === QueuingType.PlayNext)
-			await playNextInQueue({ ...variables, tracks: tracksToAdd })
-		else await playLaterInQueue({ ...variables, tracks: tracksToAdd })
+		if (variables.queuingType === QueuingType.PlayNext) {
+			// For PlayNext, pass all tracks so we can reorder existing ones
+			await playNextInQueue(variables)
+		} else {
+			// For PlayLater, only add new tracks
+			const tracksToAdd = variables.tracks.filter(
+				(item) => !actualQueueIds.includes(item.Id!),
+			)
+			await playLaterInQueue({ ...variables, tracks: tracksToAdd })
+		}
 
 		applyHapticFeedback('success')
 		Toast.show({


### PR DESCRIPTION
This pull request updates the queue management logic to better handle adding and reordering tracks in the player queue. The main improvement is that when using the "Play Next" feature, the code now distinguishes between tracks already in the queue (which are reordered) and new tracks (which are added), resulting in a more intuitive playback experience.

**Queue management improvements:**

* In `playNextInQueue`, the function now splits incoming tracks into those already in the queue (to be reordered) and new tracks (to be added), ensuring existing tracks are moved to the correct position instead of duplicated. [[1]](diffhunk://#diff-4dee0bc7c9dd71c5879d961a8eaa08d8068e2215d57a38971ef3490f78f790b5R104-R105) [[2]](diffhunk://#diff-4dee0bc7c9dd71c5879d961a8eaa08d8068e2215d57a38971ef3490f78f790b5L131-R159)
* The logic for `addToQueue` is updated so that "Play Next" passes all tracks (allowing for proper reordering), while "Play Later" only adds tracks not already present in the queue.