### PR TITLE
fix: authenticate and resolve selected track before playback

### DIFF
--- a/jest/functional/ItemToTrack.test.ts
+++ b/jest/functional/ItemToTrack.test.ts
@@ -1,0 +1,50 @@
+import { BaseItemDto, BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models'
+import { mapDtoToTrack } from '../../src/utils/mapping/item-to-track'
+import { getApi } from '../../src/stores/auth/utils'
+
+jest.mock('../../src/stores/auth/utils', () => ({
+	getApi: jest.fn(),
+}))
+
+jest.mock('../../src/api/queries/image/utils', () => ({
+	getItemImageUrl: jest.fn().mockReturnValue('https://example.com/artwork.jpg'),
+}))
+
+describe('mapDtoToTrack', () => {
+	const item = {
+		Id: 'track-1',
+		Name: 'Track 1',
+		Type: BaseItemKind.Audio,
+		ArtistItems: [],
+		RunTimeTicks: 1_800_000_000,
+	} as BaseItemDto
+
+	it('places the Jellyfin authorization header in Nitro Player extraPayload', () => {
+		;(getApi as jest.Mock).mockReturnValue({
+			accessToken: 'access-token',
+			authorizationHeader:
+				'MediaBrowser Client="Jellify", Device="iPhone", DeviceId="device", Version="1.2.7", Token="access-token"',
+		})
+
+		const track = mapDtoToTrack(item, new Map())
+
+		expect(track).not.toHaveProperty('headers')
+		expect(track.extraPayload).toMatchObject({
+			headers: {
+				Authorization:
+					'MediaBrowser Client="Jellify", Device="iPhone", DeviceId="device", Version="1.2.7", Token="access-token"',
+			},
+		})
+	})
+
+	it('omits authentication headers when there is no access token', () => {
+		;(getApi as jest.Mock).mockReturnValue({
+			accessToken: '',
+			authorizationHeader: 'MediaBrowser Client="Jellify"',
+		})
+
+		const track = mapDtoToTrack(item, new Map())
+
+		expect(track.extraPayload).not.toHaveProperty('headers')
+	})
+})

--- a/jest/functional/Player/queue.test.ts
+++ b/jest/functional/Player/queue.test.ts
@@ -154,7 +154,7 @@ describe('Queue - loadNewQueue', () => {
 		expect(TrackPlayer.skipToIndex).not.toHaveBeenCalled()
 	})
 
-	it('does not call updateTrackMediaInfo directly when starting track URL is empty (resolved by native onTracksNeedUpdate)', async () => {
+	it('resolves an empty starting track URL before playback', async () => {
 		const dto = createDto('a')
 		const trackWithoutUrl = createTrackItem('a', '')
 		;(DownloadManager.getAllDownloadedTracks as jest.Mock).mockResolvedValue([])
@@ -170,7 +170,7 @@ describe('Queue - loadNewQueue', () => {
 		})
 
 		expect(resolveTrackUrls).not.toHaveBeenCalled()
-		expect(updateTrackMediaInfo).not.toHaveBeenCalled()
+		expect(updateTrackMediaInfo).toHaveBeenCalledWith([trackWithoutUrl])
 	})
 
 	it('does not call updateTrackMediaInfo for a downloaded starting track that already has a local URL', async () => {
@@ -192,7 +192,7 @@ describe('Queue - loadNewQueue', () => {
 		expect(updateTrackMediaInfo).not.toHaveBeenCalled()
 	})
 
-	it('does not call updateTrackMediaInfo directly when all track URLs are empty (resolved by native onTracksNeedUpdate)', async () => {
+	it('only resolves the selected track directly when all track URLs are empty', async () => {
 		const dtos = [createDto('a'), createDto('b')]
 		const trackA = createTrackItem('a', '')
 		const trackB = createTrackItem('b', '')
@@ -210,7 +210,8 @@ describe('Queue - loadNewQueue', () => {
 			startPlayback: false,
 		})
 
-		expect(updateTrackMediaInfo).not.toHaveBeenCalled()
+		expect(updateTrackMediaInfo).toHaveBeenCalledTimes(1)
+		expect(updateTrackMediaInfo).toHaveBeenCalledWith([trackA])
 		expect(setNewQueue).toHaveBeenCalledWith(
 			expect.arrayContaining([
 				expect.objectContaining({ id: 'a', url: '' }),
@@ -286,6 +287,30 @@ describe('Queue - loadNewQueue', () => {
 		})
 
 		expect(TrackPlayer.play).toHaveBeenCalled()
+	})
+
+	it('updates an empty starting track before calling play', async () => {
+		const callOrder: string[] = []
+		const dto = createDto('a')
+		const track = createTrackItem('a', '')
+		;(filterTracksOnNetworkStatus as jest.Mock).mockReturnValue([dto])
+		;(mapDtoToTrack as jest.Mock).mockReturnValue(track)
+		;(updateTrackMediaInfo as jest.Mock).mockImplementation(async () => {
+			callOrder.push('updateTrackMediaInfo')
+		})
+		;(TrackPlayer.play as jest.Mock).mockImplementation(async () => {
+			callOrder.push('play')
+		})
+
+		await loadNewQueue({
+			track: dto,
+			index: 0,
+			tracklist: [dto],
+			queue: 'Library',
+			startPlayback: true,
+		})
+
+		expect(callOrder).toEqual(['updateTrackMediaInfo', 'play'])
 	})
 
 	it('calls TrackPlayer.play() after setNewQueue so the queue is ready before playback starts', async () => {

--- a/jest/functional/Player/track-media-info.test.ts
+++ b/jest/functional/Player/track-media-info.test.ts
@@ -155,11 +155,7 @@ describe('onTracksNeedUpdate', () => {
 
 		await onTracksNeedUpdate(tracks, 2)
 
-		expect(resolveTrackUrls).toHaveBeenCalledWith(
-			tracks.slice(0, 2),
-			'stream',
-			expect.any(Object),
-		)
+		expect(resolveTrackUrls).toHaveBeenCalledWith(tracks.slice(0, 2), 'stream', undefined)
 	})
 
 	it('passes all tracks when the lookahead equals or exceeds the track count', async () => {
@@ -168,6 +164,26 @@ describe('onTracksNeedUpdate', () => {
 
 		await onTracksNeedUpdate(tracks, 10)
 
-		expect(resolveTrackUrls).toHaveBeenCalledWith(tracks, 'stream', expect.any(Object))
+		expect(resolveTrackUrls).toHaveBeenCalledWith(tracks, 'stream', undefined)
+	})
+
+	it('allows overlapping track updates to finish independently', async () => {
+		const firstTrack = createTrack('a', '')
+		const secondTrack = createTrack('b', '')
+		const updatedFirst = createTrack('a', 'https://cdn.example.com/a.mp3')
+		const updatedSecond = createTrack('b', 'https://cdn.example.com/b.mp3')
+		const firstDeferred = deferred<TrackItem[]>()
+		;(resolveTrackUrls as jest.Mock)
+			.mockReturnValueOnce(firstDeferred.promise)
+			.mockResolvedValueOnce([updatedSecond])
+
+		const firstUpdate = onTracksNeedUpdate([firstTrack], 1)
+		await onTracksNeedUpdate([secondTrack], 1)
+		firstDeferred.resolve([updatedFirst])
+		await firstUpdate
+
+		expect(TrackPlayer.updateTracks).toHaveBeenCalledTimes(2)
+		expect(TrackPlayer.updateTracks).toHaveBeenCalledWith([updatedFirst])
+		expect(TrackPlayer.updateTracks).toHaveBeenCalledWith([updatedSecond])
 	})
 })

--- a/src/player/queuing/index.ts
+++ b/src/player/queuing/index.ts
@@ -7,11 +7,17 @@ import { applyHapticFeedback } from '../../utils/haptics'
 import playNextInQueue from './play-next'
 import playLaterInQueue from './play-later'
 import loadQueue from './load'
+import { updateTrackMediaInfo } from '../../services/player/utils/track-media-info'
 
 export const loadNewQueue = async (variables: QueueMutation) => {
 	applyHapticFeedback('info')
 
-	await loadQueue({ ...variables })
+	const { finalStartIndex, tracks } = await loadQueue({ ...variables })
+	const startingTrack = tracks[finalStartIndex]
+
+	if (startingTrack && !startingTrack.url) {
+		await updateTrackMediaInfo([startingTrack])
+	}
 
 	if (variables.startPlayback) {
 		await TrackPlayer.play()

--- a/src/services/player/utils/event-handlers.ts
+++ b/src/services/player/utils/event-handlers.ts
@@ -8,16 +8,8 @@ import { captureError } from '../../../utils/logging'
 import LoggingContext from '../../../utils/logging/enums'
 import { updateTrackMediaInfo } from './track-media-info'
 import reportPlaybackCompleted from '../../../api/mutations/playback/functions/playback-completed'
-import { AppState, Platform } from 'react-native'
+import { AppState } from 'react-native'
 import reportPlaybackStarted from '../../../api/mutations/playback/functions/playback-started'
-
-/**
- * {@link AbortController} for signalling when to bail from an "onTracksNeedUpdate".
- * event.
- *
- * This is only used on iOS
- */
-let trackUpdateAbortController: AbortController | null = null
 
 /**
  * Tracks the most recent playback state so that resume-from-pause can be
@@ -53,15 +45,11 @@ export async function onTracksNeedUpdate(tracks: TrackItem[], lookahead: number)
 		`[Player Event] onTracksNeedUpdate triggered for ${tracks.length} track(s). Updating media info...`,
 	)
 
-	trackUpdateAbortController?.abort()
-
 	const tracksToUpdate = lookahead > 0 ? tracks.slice(0, lookahead) : tracks
 
 	console.debug(`[Player Event] Updating media info for track lookahead ${tracksToUpdate.length}`)
 
-	trackUpdateAbortController = Platform.OS === 'ios' ? new AbortController() : null
-
-	await updateTrackMediaInfo(tracksToUpdate, trackUpdateAbortController?.signal)
+	await updateTrackMediaInfo(tracksToUpdate)
 }
 
 /**

--- a/src/types/JellifyTrack.ts
+++ b/src/types/JellifyTrack.ts
@@ -35,6 +35,7 @@ export type TrackExtraPayload = Record<string, unknown> & {
 	 */
 	mediaSourceInfo: string
 	blurhash?: string
+	headers?: Record<string, string>
 }
 
 export type SlimifiedBaseItemDto = Pick<

--- a/src/utils/mapping/item-to-track.ts
+++ b/src/utils/mapping/item-to-track.ts
@@ -1,6 +1,5 @@
 import { BaseItemDto, BaseItemKind, ImageType } from '@jellyfin/sdk/lib/generated-client/models'
 import { TrackExtraPayload } from '../../types/JellifyTrack'
-import { Api } from '@jellyfin/sdk/lib/api'
 import { convertRunTimeTicksToSeconds } from './ticks-to-seconds'
 import { getApi } from '../../stores/auth/utils'
 import { DownloadedTrack, TrackItem } from 'react-native-nitro-player'
@@ -43,10 +42,7 @@ export function mapDtoToTrack(
 		? getTrackMediaSourceInfo(downloadedTrack.originalTrack)
 		: ({} as const)
 
-	// Only include headers when we have an API token (streaming cases). For downloaded tracks it's not needed.
-	const headers = (api as Api | undefined)?.accessToken
-		? { AUTHORIZATION: (api as Api).accessToken }
-		: undefined
+	const headers = api.accessToken ? { Authorization: api.authorizationHeader } : undefined
 
 	if (downloadedTrack?.localPath) {
 		console.debug('Downloaded track path', `file://${downloadedTrack.localPath}`)
@@ -57,7 +53,6 @@ export function mapDtoToTrack(
 	}
 
 	return {
-		...(headers ? { headers } : {}),
 		id: item.Id ?? '',
 		url: downloadedTrack?.localPath ? `file://${downloadedTrack.localPath}` : '',
 		artwork: downloadedTrack?.localArtworkPath
@@ -82,6 +77,7 @@ export function mapDtoToTrack(
 			mediaSourceInfo: JSON.stringify(mediaSourceInfo), // This will be populated later in the playback flow when we have the MediaSourceInfo available
 			sessionId: '',
 			blurhash: getBlurhashFromDto(item),
+			...(headers ? { headers } : {}),
 		} as TrackExtraPayload,
 	} as TrackItem
 }


### PR DESCRIPTION
## What changed

- Put Jellyfin authentication in `extraPayload.headers`, the field Nitro Player 1.5.0 reads on iOS and Android
- Use the SDK-generated `MediaBrowser` authorization value instead of a raw token
- Resolve an empty selected-track URL before calling `TrackPlayer.play()`
- Let overlapping `onTracksNeedUpdate` requests complete independently instead of globally aborting the earlier iOS request
- Add regressions for native track auth shape, update-before-play ordering, and overlapping URL updates

## Why

On Jellify 1.2.7 for iOS, selecting a current Jellyfin item can fetch `PlaybackInfo` successfully but never issue the subsequent `/Audio/{id}/stream` request. The Jellyfin session remains paused at 0 ms. A live reproduction generated repeated PlaybackInfo requests but no audio request.

The immediate blocker is that Jellify stores `headers` at the top level of `TrackItem`, while Nitro Player explicitly reads `extraPayload.headers`. The native player therefore receives no usable Jellyfin authorization. The selected queue entry also starts with `url: ""`, and a second lazy-load callback could abort the first selected-track request.

This addresses the first-track/paused-at-zero failure mode reported in #1214.

## Validation

- `bunx jest jest/functional/ItemToTrack.test.ts jest/functional/Player/queue.test.ts jest/functional/Player/track-media-info.test.ts --runInBand` (42 tests pass)
- `bun run tsc`
- Focused ESLint passes
- Full unsigned iOS Debug build succeeds with Xcode 26.0.1
