### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,4 +324,4 @@ Patreon supporters on the **$5 or $10 tier** who stay subscribed for **3 months*
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=anultravioletaurora/Jellify,Jellify-Music/App&type=Date)](https://www.star-history.com/#anultravioletaurora/Jellify&Jellify-Music/App&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=anultravioletaurora/Jellify,Jellify-Music/App&type=Date)](https://star-history.dera.page/#anultravioletaurora/Jellify&Jellify-Music/App&Date)


### PR DESCRIPTION
The star history chart on the README is currently broken because the underlying source stopped working due to GitHub stargazer API restrictions. This updates the chart link so it loads correctly again.