### PR TITLE
[FIXED] Instant crash on launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ local.properties
 .cxx/
 *.keystore
 !debug.keystore
+android/app/*.keystore
+android/app/keystore.properties
 
 # node.js
 #

--- a/ANDROID-NOTES.md
+++ b/ANDROID-NOTES.md
@@ -1,0 +1,104 @@
+# Android debugging notes
+
+Findings from a debugging session on a Pixel 9 running LineageOS + microG
+(2026-08-28). Kept here because these items span the codebase and have no single
+code location; site-specific notes live as comments in the relevant files.
+
+## Test release builds, not just debug builds
+
+The most important lesson from that session. Two of the bugs below were **fatal in
+release and non-fatal in debug**, because React Native's dev error handling catches a
+thrown exception and shows a red box, while an uncaught exception in a release build
+kills the process instantly.
+
+A debug build reporting "works fine" tells you very little about release. Verify with:
+
+```sh
+cd android && ./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a
+adb install app/build/outputs/apk/release/app-arm64-v8a-release.apk
+```
+
+To read a crash from a release build:
+
+```sh
+adb logcat -c
+# launch the app, let it crash
+adb logcat -b crash -d
+```
+
+Note that `src/utils/console-override.ts` no-ops `console.error` in release, so a JS
+error produces no output at all. Comment out its initializer when chasing a
+release-only bug. Note also that class names in a release stack trace are obfuscated
+by R8 into forms like `R2.a`; error *messages* come through intact.
+
+## Fixed in this session
+
+**`Invalid font weight value: 32` — crash on launch, release only.** Tamagui weight
+tokens (`'$6'`, `'$8'`) do not resolve against the font's weight scale when a style
+flows through the Reanimated animation driver — they resolve against the *space* scale,
+where `$6` is 32 and `$4` is 18. Reanimated's `processFontWeight` accepts only real CSS
+weights and throws on anything else. Fix was to use literal weight strings everywhere.
+See the extended comment in `src/components/Global/helpers/text.tsx`.
+
+Filling out the weight scale in `src/configs/styling/fonts.ts` does **not** make tokens
+safe; the token never reaches that scale on animated components.
+
+**`Cannot have more than one child view...` — crash on every track change.** RNGH 3.x
+asserts a `GestureDetector` owns exactly one child, but Reanimated's exiting layout
+animations keep the outgoing view mounted while adding the incoming one. Fix was a
+stable non-collapsible wrapper `View`. See `src/components/Player/components/header.tsx`.
+
+## Already optimised — do not redo this analysis
+
+A dependency audit suggested a list of optimisations that turned out to be already
+implemented. For the record:
+
+| Suggestion | Actual state |
+| --- | --- |
+| Use `@legendapp/list` | Already the list library throughout |
+| Tree-shake vector icons | Already using the scoped per-family package, not the monolith |
+| Enable Hermes bytecode cache | Hermes is on; release builds already ship precompiled bytecode. Nothing to enable |
+| Lazy-load heavy scenes | `lazy: true` already set on bottom tabs and library top tabs |
+| `unmountOnBlur` on tabs | Removed in React Navigation 7 (this app's version). `enableFreeze(true)` in `index.js` already covers it, and preserves state |
+| `React.memo` expensive components | `babel-plugin-react-compiler` is enabled and auto-memoises. Manual memo is redundant; CONTRIBUTING.md forbids `useMemo`/`useCallback` for the same reason |
+| `lodash-es` for tree-shaking | Metro does not tree-shake by default; `lodash-es` yields nothing here and often breaks RN builds. Per-method imports or removal is the real option |
+| Swap Tamagui for styled-components | Tamagui compiles styles at build time via `@tamagui/babel-plugin`. styled-components is runtime CSS-in-JS — this would be *slower*, across 110+ files |
+
+APK size is dominated by native `.so` payloads (Reanimated, quick-crypto, nitro-player,
+gesture-handler), not JavaScript. Per-ABI splits and ProGuard are already enabled.
+
+## Open items
+
+**RNGH 2 API used on RNGH 3.** `Gesture.Pan`, `Gesture.Tap`, `Gesture.Race`,
+`Gesture.LongPress`, `GestureObjects` and `triggerHaptic` are all deprecated in
+react-native-gesture-handler 3.x, and 4 files still use them. Migrating removes a class
+of version-mismatch bugs like the one fixed above.
+
+**`react-native-drax@1.1.0` declares no RNGH 3 support** (peer range `>=2.0.0`). It
+powers drag-to-reorder in Queue and Playlist. See the note in
+`src/components/Queue/index.tsx`.
+
+**`openai` is in `dependencies` but only used by `scripts/generate-release-notes.js`.**
+It never reaches the app bundle, so this is a classification issue rather than a size
+problem — it belongs in `devDependencies`.
+
+**`lodash` is imported in 47 files**, overwhelmingly for `isUndefined`, which is just
+`x === undefined`. Removing the dependency is mechanical and low-risk.
+
+**`react-native-uuid` could be dropped** once `globals.js` stops clobbering the `crypto`
+global — see the comment there. `react-native-quick-crypto` already provides
+`randomUUID`.
+
+**`react-native-linear-gradient` has exactly one consumer.** `react-native-svg` is
+already a dependency and can replace it. See
+`src/components/Player/components/blurred-background.tsx`.
+
+**ProGuard keep rules are thin** and R8 is already breaking one reflective call
+(non-fatal). See `android/app/proguard-rules.pro`.
+
+**The media service outlives a UI crash**, leaving a zombie process that must be
+force-stopped. See `index.js`.
+
+**Performance monitoring is itself a performance problem** in list items. See
+`src/hooks/use-performance-monitor.ts` and the `TODO` in
+`src/components/Global/components/item-card.tsx`.

--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,10 @@ import QueryPersistenceConfig from './src/configs/query-persistence.config'
 import { ReducedMotionConfig, ReduceMotion } from 'react-native-reanimated'
 import { useOtaUpdate } from './src/hooks/ota'
 
+// NOTE: this hides the LogBox overlay but does NOT make logging free. Console calls
+// still run through LogBoxData.addLog and are forwarded to Metro, so noisy components
+// remain expensive in debug builds even though nothing appears on screen. Suppressing
+// the overlay also means real errors are easy to miss — check the Metro terminal.
 LogBox.ignoreAllLogs()
 
 export default function App(): React.JSX.Element {
@@ -28,6 +32,15 @@ export default function App(): React.JSX.Element {
 	const handleRetry = () => setReloader((r) => r + 1)
 
 	return (
+		/*
+		 * NOTE: StrictMode deliberately double-invokes renders and effects in dev only
+		 * (it is inert in release). That is useful for surfacing impure renders, but it
+		 * also doubles the work behind every interaction in debug builds and can create
+		 * transient view states that native code does not expect — it was a suspected
+		 * amplifier of the react-native-gesture-handler "more than one child view"
+		 * assertion. If a dev-only crash resists explanation, try removing this wrapper
+		 * as a diagnostic; it changes nothing about release behaviour.
+		 */
 		<React.StrictMode>
 			<SafeAreaProvider>
 				<ErrorBoundary reloader={reloader} onRetry={handleRetry}>

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -11,3 +11,24 @@
 
 
 -keep class com.jellify.BuildConfig { *; }
+
+# KNOWN GAP: these rules are thin for an app with this many native modules, and R8
+# is demonstrably breaking at least one reflective call. A release build logs:
+#
+#   RNInstallReferrerClient exception. getInstallReferrer will be unavailable:
+#   java.lang.NoSuchMethodException: R2.a.newBuilder [class android.content.Context]
+#
+# "R2.a" is an R8-obfuscated name, so the Install Referrer client is looking up a
+# method on a class R8 has renamed. That one is caught and non-fatal, but it shows
+# reflective access is not protected here in general.
+#
+# Classes referenced only from AndroidManifest metadata strings are the highest risk,
+# since R8 sees no code reference and may strip or rename them. One example present in
+# this app is nitro-player's Cast provider, declared in its library manifest as
+# com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME =
+# com.margelo.nitro.nitroplayer.media.NitroCastOptionsProvider. It has not been
+# observed failing, but it fits the pattern and would only break in release builds.
+#
+# To test whether R8 is implicated in any future release-only crash, flip
+# enableProguardInReleaseBuilds to false in build.gradle and rebuild. If the crash
+# disappears, add keep rules rather than leaving minification off.

--- a/globals.js
+++ b/globals.js
@@ -1,6 +1,20 @@
 import * as Crypto from 'react-native-quick-crypto'
 
 // https://telemetrydeck.com/docs/guides/react-setup/#react-native-%26-expo-support
+//
+// KNOWN ISSUE: this *replaces* the entire `crypto` global rather than extending it,
+// so `crypto.randomUUID` and `crypto.getRandomValues` do not exist anywhere in the
+// app. Anything reaching for them silently gets `undefined` and fails.
+//
+// Consequences:
+//   - `crypto.randomUUID()` cannot be used, which is why react-native-uuid is still
+//     a dependency across 9 files.
+//   - Any library expecting a standards-shaped `crypto` object will break here.
+//
+// Fix would be to spread the existing global instead of overwriting it, or install
+// react-native-quick-crypto's full polyfill (it provides randomUUID and
+// getRandomValues, and is already a dependency). Verify nothing depends on the
+// current narrow shape before changing it.
 globalThis.crypto = {
 	subtle: {
 		digest: (algorithm, message) => Crypto.digest(algorithm, message),

--- a/index.js
+++ b/index.js
@@ -22,6 +22,18 @@ Sentry.init({
 	enabled: !!GLITCHTIP_DSN,
 })
 
+// KNOWN ISSUE (Android): NitroPlayerPlaybackService outlives a UI crash. When the JS
+// side dies, the foreground media service is restarted by the system and keeps the
+// process alive, so tapping the launcher icon resumes a dead process and nothing draws.
+// Only `adb shell am force-stop com.cosmonautical.jellify` clears it. Observed via:
+//
+//   dumpsys activity services com.cosmonautical.jellify
+//   -> crashCount=1 restartCount=1 isForeground=false, and every FGS allow-check DENIED
+//      (targetSdkVersion=36, so Android 16 foreground-service restrictions apply)
+//
+// Practical impact while debugging: force-stop between runs, or you may be testing a
+// zombie process. A proper fix likely means tearing the service down when the React
+// instance is destroyed, and not calling startForeground when the checks will deny it.
 registerNitroPlayer()
 configureDownloadManager()
 

--- a/src/api/queries/lyrics/utils/index.ts
+++ b/src/api/queries/lyrics/utils/index.ts
@@ -11,12 +11,16 @@ export interface ParsedLyricLine {
 
 /**
  * Fetch raw lyrics text for a given track item.
+ *
+ * Resolves to `null` when the track has no lyrics. TanStack Query rejects
+ * `undefined` as a query result, so returning it logs "Query data cannot be
+ * undefined" and leaves the query permanently unresolved.
  */
 export async function fetchRawLyrics(
 	api: Api | undefined,
 	itemId: string,
 	signal?: AbortSignal,
-): Promise<LyricDto['Lyrics'] | undefined> {
+): Promise<NonNullable<LyricDto['Lyrics']> | null> {
 	if (isUndefined(api)) throw new Error('Client not initialized')
 	if (isEmpty(itemId)) throw new Error('No item ID provided')
 
@@ -26,10 +30,11 @@ export async function fetchRawLyrics(
 		const lyricsApi: LyricsApi = getLyricsApi(api)
 		const { data } = await lyricsApi.getLyrics({ itemId }, { signal })
 
-		// Some SDK versions may wrap text; defensively unwrap
-		return data.Lyrics
+		// Some SDK versions may wrap text; defensively unwrap.
+		// Tracks without lyrics come back with no Lyrics field at all.
+		return data.Lyrics ?? null
 	} catch (e) {
 		console.warn('Failed to fetch lyrics', e)
-		return undefined
+		return null
 	}
 }

--- a/src/components/Album/header.tsx
+++ b/src/components/Album/header.tsx
@@ -63,7 +63,7 @@ export default function AlbumTrackListHeader({ album }: { album: BaseItemDto }):
 
 				{album.AlbumArtists && album.AlbumArtists.length > 0 && (
 					<Paragraph
-						fontWeight={'$6'}
+						fontWeight={'600'}
 						color={'$primary'}
 						onPress={() =>
 							navigation.navigate('Artist', {
@@ -111,7 +111,7 @@ export default function AlbumTrackListHeader({ album }: { album: BaseItemDto }):
 							onPress={() => playAlbum(false)}
 							{...BUTTON_PRESS_STYLES}
 						>
-							<Paragraph fontWeight={'$6'} color={'$background'}>
+							<Paragraph fontWeight={'600'} color={'$background'}>
 								Play
 							</Paragraph>
 						</Button>
@@ -125,7 +125,7 @@ export default function AlbumTrackListHeader({ album }: { album: BaseItemDto }):
 							onPress={() => playAlbum(true)}
 							{...BUTTON_PRESS_STYLES}
 						>
-							<Paragraph fontWeight={'$6'} color={'$primary'}>
+							<Paragraph fontWeight={'600'} color={'$primary'}>
 								Shuffle
 							</Paragraph>
 						</Button>

--- a/src/components/Artist/header.tsx
+++ b/src/components/Artist/header.tsx
@@ -65,7 +65,7 @@ export default function ArtistHeader(): React.JSX.Element {
 			<YStack paddingHorizontal={'$2'}>
 				<XStack alignItems='flex-end' justifyContent='flex-start' flex={1}>
 					<XStack alignItems='center' flex={1} justifyContent='space-between'>
-						<H5 flexGrow={1} fontWeight={'$6'}>
+						<H5 flexGrow={1} fontWeight={'600'}>
 							{artist.Name}
 						</H5>
 					</XStack>
@@ -102,7 +102,7 @@ export default function ArtistHeader(): React.JSX.Element {
 					}
 					{...ICON_PRESS_STYLES}
 				>
-					<Paragraph fontWeight={'$6'} fontSize={'$4'}>
+					<Paragraph fontWeight={'600'} fontSize={'$4'}>
 						{`View Tracks`}
 					</Paragraph>
 

--- a/src/components/CastDialog/index.tsx
+++ b/src/components/CastDialog/index.tsx
@@ -29,7 +29,7 @@ function CastDialogNoDevices() {
 	return (
 		<YStack justifyContent='center' alignContent='center'>
 			<Icon large name='speaker-off' />
-			<Paragraph fontWeight={'$6'}>Use the Cast button to pick a device</Paragraph>
+			<Paragraph fontWeight={'600'}>Use the Cast button to pick a device</Paragraph>
 		</YStack>
 	)
 }

--- a/src/components/Context/components/instant-mix-row.tsx
+++ b/src/components/Context/components/instant-mix-row.tsx
@@ -19,7 +19,7 @@ export default function ViewInstantMixMenuRow({ item }: { item: BaseItemDto }): 
 		>
 			<Icon small color='$success' name='access-point' />
 
-			<Paragraph fontWeight={'$6'}>{`Go to ${getItemName(item)} Mix`}</Paragraph>
+			<Paragraph fontWeight={'600'}>{`Go to ${getItemName(item)} Mix`}</Paragraph>
 		</ListItem>
 	)
 }

--- a/src/components/Context/index.tsx
+++ b/src/components/Context/index.tsx
@@ -185,7 +185,7 @@ function AddToPlaylistRow({
 		>
 			<Icon small color='$primary' name='plus-circle-outline' />
 
-			<Paragraph fontWeight={'$6'}>Add to Playlist</Paragraph>
+			<Paragraph fontWeight={'600'}>Add to Playlist</Paragraph>
 		</ListItem>
 	)
 }
@@ -213,7 +213,7 @@ function AddToQueueMenuRow({ tracks }: { tracks: BaseItemDto[] }): React.JSX.Ele
 				{/* Use same icon as swipe Add to Queue for consistency */}
 				<Icon small color='$primary' name='playlist-play' />
 
-				<Paragraph fontWeight={'$6'}>Play Next</Paragraph>
+				<Paragraph fontWeight={'600'}>Play Next</Paragraph>
 			</ListItem>
 
 			<ListItem
@@ -232,7 +232,7 @@ function AddToQueueMenuRow({ tracks }: { tracks: BaseItemDto[] }): React.JSX.Ele
 				{/* Consistent Add to Queue icon */}
 				<Icon small color='$primary' name='playlist-play' />
 
-				<Paragraph fontWeight={'$6'}>Add to Queue</Paragraph>
+				<Paragraph fontWeight={'600'}>Add to Queue</Paragraph>
 			</ListItem>
 		</>
 	)
@@ -264,7 +264,7 @@ function DownloadMenuRow({ items }: { items: BaseItemDto[] }): React.JSX.Element
 		>
 			<CircularProgressIndicator progress={overallProgress} size={24} strokeWidth={4} />
 
-			<Paragraph fontWeight={'$6'} color={'$borderColor'}>
+			<Paragraph fontWeight={'600'} color={'$borderColor'}>
 				Download Queued
 			</Paragraph>
 		</ListItem>
@@ -284,7 +284,7 @@ function DownloadMenuRow({ items }: { items: BaseItemDto[] }): React.JSX.Element
 				name={items.length > 1 ? 'download-multiple' : 'download'}
 			/>
 
-			<Paragraph fontWeight={'$6'}>Download</Paragraph>
+			<Paragraph fontWeight={'600'}>Download</Paragraph>
 		</ListItem>
 	)
 
@@ -298,7 +298,7 @@ function DownloadMenuRow({ items }: { items: BaseItemDto[] }): React.JSX.Element
 		>
 			<Icon small color='$warning' name='broom' />
 
-			<Paragraph fontWeight={'$6'}>Remove Download</Paragraph>
+			<Paragraph fontWeight={'600'}>Remove Download</Paragraph>
 		</ListItem>
 	)
 
@@ -336,7 +336,7 @@ function ViewAlbumMenuRow({ album: album, stackNavigation }: MenuRowProps): Reac
 			/>
 
 			<TextTicker {...TextTickerConfig}>
-				<Paragraph fontWeight={'$6'}>{`Go to ${getItemName(album)}`}</Paragraph>
+				<Paragraph fontWeight={'600'}>{`Go to ${getItemName(album)}`}</Paragraph>
 			</TextTicker>
 		</ListItem>
 	)
@@ -390,7 +390,7 @@ function ViewArtistMenuRow({
 				imageOptions={{ maxWidth: 50, maxHeight: 50, quality: 100 }}
 			/>
 
-			<Paragraph fontWeight={'$6'}>{`Go to ${getItemName(artist)}`}</Paragraph>
+			<Paragraph fontWeight={'600'}>{`Go to ${getItemName(artist)}`}</Paragraph>
 		</ListItem>
 	) : (
 		<></>
@@ -423,7 +423,7 @@ function StatsRow({
 		>
 			<Icon small name='sine-wave' color='$primary' />
 
-			<Paragraph fontWeight={'$6'}>Open Audio Specs</Paragraph>
+			<Paragraph fontWeight={'600'}>Open Audio Specs</Paragraph>
 		</ListItem>
 	)
 }

--- a/src/components/Global/components/AZScroller/index.tsx
+++ b/src/components/Global/components/AZScroller/index.tsx
@@ -176,7 +176,7 @@ export default function AZScroller({
 			userSelect='none'
 			color={'$borderColor'}
 			fontSize={'$6'}
-			fontWeight={'$6'}
+			fontWeight={'600'}
 			textAlign='center'
 		>
 			{letter}

--- a/src/components/Global/components/SwipeableRow/index.tsx
+++ b/src/components/Global/components/SwipeableRow/index.tsx
@@ -109,6 +109,10 @@ export default function SwipeableRow({
 	}
 
 	const close = () => {
+		// TODO: leftover debug logging. These [SR] logs fire on every swipe open/close and
+		// on every pan end (see pan.onEnd below). SwipeableRow wraps list rows, so this is
+		// a hot path — and each console call in a debug build goes through LogBox and out
+		// to Metro. Remove, or gate behind a local DEBUG_SWIPEABLE_ROW flag.
 		console.log('[SR] close() tx=', tx.value, 'id=', idRef.current)
 		syncClosedState()
 		runOnUI(() => {

--- a/src/components/Global/components/instant-mix-button.tsx
+++ b/src/components/Global/components/instant-mix-button.tsx
@@ -51,7 +51,7 @@ export function InstantMixButton({
 			borderWidth={'$1'}
 			{...BUTTON_PRESS_STYLES}
 		>
-			<Paragraph fontWeight={'$6'} color={'$success'}>
+			<Paragraph fontWeight={'600'} color={'$success'}>
 				Mix
 			</Paragraph>
 		</Button>

--- a/src/components/Global/components/item-card.tsx
+++ b/src/components/Global/components/item-card.tsx
@@ -40,6 +40,13 @@ export default function ItemCard({
 	captionAlign = 'center',
 	...cardProps
 }: CardProps) {
+	// TODO: remove this call. ItemCard is a list item — it renders once per album /
+	// artist / track card on Home, Search and the Library tabs. With a threshold of 2,
+	// every card console.warns after its second render, and in a debug build each of
+	// those is routed through LogBox and shipped to Metro over the websocket. Dozens
+	// to hundreds of them per interaction is a measurable JS-thread stall, which is a
+	// strong suspect for the sluggish, unresponsive-button feel in debug builds.
+	// See the warning on usePerformanceMonitor itself.
 	usePerformanceMonitor('ItemCard', 2)
 
 	const warmContext = useItemContext()

--- a/src/components/Global/components/library-selector.tsx
+++ b/src/components/Global/components/library-selector.tsx
@@ -88,7 +88,9 @@ export default function LibrarySelector({
 				borderColor={isSelected ? '$primary' : '$borderColor'}
 			>
 				<Paragraph
-					fontWeight={isSelected ? '$8' : 'unset'}
+					// 'unset' is not a legal Reanimated font weight either; see the note
+					// in Global/helpers/text.tsx.
+					fontWeight={isSelected ? '800' : '400'}
 					color={isSelected ? '$background' : '$neutral'}
 				>
 					{library.Name ?? 'Unnamed Library'}
@@ -171,7 +173,7 @@ export default function LibrarySelector({
 					testID='let_s_go_button'
 					flex={1}
 				>
-					<Paragraph color={'$primary'} fontWeight={'$6'}>
+					<Paragraph color={'$primary'} fontWeight={'600'}>
 						{primaryButtonText}
 					</Paragraph>
 				</Button>

--- a/src/components/Global/helpers/input.tsx
+++ b/src/components/Global/helpers/input.tsx
@@ -71,7 +71,7 @@ export default function Input(props: InputProps): React.JSX.Element {
 	return (
 		<YStack>
 			{props.title && (
-				<Paragraph fontWeight={'$6'} color={'$borderColor'}>
+				<Paragraph fontWeight={'600'} color={'$borderColor'}>
 					{props.title}
 				</Paragraph>
 			)}

--- a/src/components/Global/helpers/list-sticky-header.tsx
+++ b/src/components/Global/helpers/list-sticky-header.tsx
@@ -10,7 +10,7 @@ export default function ListStickyHeader({ text }: { text: string }): React.JSX.
 			borderColor={'$primary'}
 			backgroundColor={'$background'}
 		>
-			<Paragraph margin={'$2'} fontSize={'$6'} fontWeight={'$6'} color={'$primary'}>
+			<Paragraph margin={'$2'} fontSize={'$6'} fontWeight={'600'} color={'$primary'}>
 				{text}
 			</Paragraph>
 		</XStack>

--- a/src/components/Global/helpers/text.tsx
+++ b/src/components/Global/helpers/text.tsx
@@ -71,7 +71,22 @@ export function Text(props: TextProps): React.JSX.Element {
 	return (
 		<Paragraph
 			{...props}
-			fontWeight={props.bold ? '$6' : '$4'}
+			/*
+			 * Do not use Tamagui weight tokens ('$6', '$4', ...) for fontWeight.
+			 *
+			 * This app drives Tamagui animations with Reanimated
+			 * (@tamagui/config/v5-reanimated), so styles on animated components are
+			 * handed to Reanimated's processFontWeight, which accepts only real CSS
+			 * weights (100-900) and the named aliases in FONT_WEIGHT_MAPPINGS.
+			 * A weight token does not resolve against the font's weight scale here;
+			 * it resolves against the space scale, where '$6' is 32 and '$4' is 18.
+			 * Reanimated then throws "Invalid font weight value: 32". In debug that
+			 * surfaces as a red box, but in a release build the uncaught exception
+			 * kills the process on launch.
+			 *
+			 * Always use literal weight strings.
+			 */
+			fontWeight={props.bold ? '600' : '400'}
 			fontSize='$4'
 			lineHeight={'$1'}
 			lineBreakMode='clip'

--- a/src/components/Global/helpers/time-codes.tsx
+++ b/src/components/Global/helpers/time-codes.tsx
@@ -13,7 +13,7 @@ export function RunTimeSeconds({
 }): React.JSX.Element {
 	return (
 		<Paragraph
-			fontWeight={'$6'}
+			fontWeight={'600'}
 			color={color}
 			textAlign={alignment}
 			fontVariant={['tabular-nums']}

--- a/src/components/Library/tab-bar.tsx
+++ b/src/components/Library/tab-bar.tsx
@@ -71,7 +71,7 @@ function LibraryTabBar(props: MaterialTopTabBarProps) {
 						>
 							<Icon name={'plus-circle-outline'} color={'$primary'} />
 
-							<Paragraph fontWeight={'$6'} color={'$primary'}>
+							<Paragraph fontWeight={'600'} color={'$primary'}>
 								Create Playlist
 							</Paragraph>
 						</XStack>
@@ -86,7 +86,7 @@ function LibraryTabBar(props: MaterialTopTabBarProps) {
 						>
 							<Icon name={'shuffle'} color={'$borderColor'} />
 
-							<Paragraph fontWeight={'$6'} color={'$borderColor'}>
+							<Paragraph fontWeight={'600'} color={'$borderColor'}>
 								All
 							</Paragraph>
 						</XStack>
@@ -107,7 +107,7 @@ function LibraryTabBar(props: MaterialTopTabBarProps) {
 							>
 								<Icon name={'sort'} color={'$borderColor'} />
 
-								<Paragraph fontWeight={'$6'} color={'$borderColor'}>
+								<Paragraph fontWeight={'600'} color={'$borderColor'}>
 									Sort
 								</Paragraph>
 							</XStack>
@@ -129,7 +129,7 @@ function LibraryTabBar(props: MaterialTopTabBarProps) {
 								/>
 
 								<Paragraph
-									fontWeight={'$6'}
+									fontWeight={'600'}
 									color={hasActiveFilters ? '$primary' : '$borderColor'}
 								>
 									Filter
@@ -172,7 +172,7 @@ function LibraryTabBar(props: MaterialTopTabBarProps) {
 							>
 								<Icon name={'filter-remove'} color={'$borderColor'} />
 
-								<Paragraph fontWeight={'$6'} color={'$borderColor'}>
+								<Paragraph fontWeight={'600'} color={'$borderColor'}>
 									Clear
 								</Paragraph>
 							</XStack>

--- a/src/components/Login/quick-connect.tsx
+++ b/src/components/Login/quick-connect.tsx
@@ -85,7 +85,7 @@ function QuickConnectDisplay({
 			>
 				<Icon small name={copyIconName} color='$primary' />
 
-				<Paragraph fontSize={'$8'} fontWeight={'$6'} color={'$primary'}>
+				<Paragraph fontSize={'$8'} fontWeight={'600'} color={'$primary'}>
 					{code}
 				</Paragraph>
 			</XStack>
@@ -127,7 +127,7 @@ export default function QuickConnectInitiator() {
 						})
 					}}
 				>
-					<Paragraph fontWeight={'$6'}>Sign in Manually</Paragraph>
+					<Paragraph fontWeight={'600'}>Sign in Manually</Paragraph>
 				</Button>
 			</XStack>
 
@@ -148,7 +148,7 @@ export default function QuickConnectInitiator() {
 						Quick Connect
 					</H3>
 
-					<Paragraph fontSize={'$6'} fontWeight={'$6'} textAlign='center' margin={'$2'}>
+					<Paragraph fontSize={'$6'} fontWeight={'600'} textAlign='center' margin={'$2'}>
 						Enter the code in another session
 					</Paragraph>
 				</Animated.View>

--- a/src/components/Login/server-address.tsx
+++ b/src/components/Login/server-address.tsx
@@ -61,7 +61,7 @@ export default function ServerAddress(): React.JSX.Element {
 					Welcome!
 				</H3>
 
-				<Paragraph fontSize={'$6'} fontWeight={'$6'} textAlign='center' margin={'$2'}>
+				<Paragraph fontSize={'$6'} fontWeight={'600'} textAlign='center' margin={'$2'}>
 					Let&apos;s get connected to Jellyfin
 				</Paragraph>
 			</Animated.View>
@@ -89,7 +89,7 @@ export default function ServerAddress(): React.JSX.Element {
 					onPress={connectWithAddress}
 					testID='connect_button'
 					color='$background'
-					fontWeight='$6'
+					fontWeight='600'
 					{...BUTTON_PRESS_STYLES}
 				>
 					{isPending ? <Spinner color='$background' /> : 'Connect'}

--- a/src/components/Login/server-authentication.tsx
+++ b/src/components/Login/server-authentication.tsx
@@ -62,7 +62,7 @@ export default function ServerAuthentication(): React.JSX.Element {
 					icon={() => <Icon name='chevron-left' small />}
 					borderRadius={'$4'}
 					onPress={onSignInPress}
-					fontWeight='$6'
+					fontWeight='600'
 					{...ICON_PRESS_STYLES}
 				>
 					{'Switch Server'}
@@ -88,7 +88,7 @@ export default function ServerAuthentication(): React.JSX.Element {
 					>
 						{`Sign in to ${server?.name ?? 'Jellyfin'}`}
 					</H3>
-					<Paragraph fontSize={'$6'} fontWeight={'$6'} textAlign='center' margin={'$2'}>
+					<Paragraph fontSize={'$6'} fontWeight={'600'} textAlign='center' margin={'$2'}>
 						{server?.version ?? 'Unknown Jellyfin version'}
 					</Paragraph>
 				</Animated.View>
@@ -146,7 +146,7 @@ export default function ServerAuthentication(): React.JSX.Element {
 						testID='sign_in_button'
 						onPress={onSubmitEditing}
 						color='$background'
-						fontWeight='$6'
+						fontWeight='600'
 						{...BUTTON_PRESS_STYLES}
 					>
 						{isPending ? <Spinner color='$background' /> : 'Sign in'}
@@ -159,7 +159,7 @@ export default function ServerAuthentication(): React.JSX.Element {
 							borderRadius={'$2'}
 							onPress={() => navigation.navigate('QuickConnect')}
 							color='$primary'
-							fontWeight='$6'
+							fontWeight='600'
 							{...ICON_PRESS_STYLES}
 						>
 							{'Use Quick Connect'}

--- a/src/components/Login/server-library.tsx
+++ b/src/components/Login/server-library.tsx
@@ -50,7 +50,7 @@ export default function ServerLibrary(): React.JSX.Element {
 					}}
 					{...ICON_PRESS_STYLES}
 				>
-					<Paragraph fontWeight={'$6'}>Switch User</Paragraph>
+					<Paragraph fontWeight={'600'}>Switch User</Paragraph>
 				</Button>
 			</XStack>
 

--- a/src/components/Network/internetConnectionWatcher.tsx
+++ b/src/components/Network/internetConnectionWatcher.tsx
@@ -122,7 +122,7 @@ const InternetConnectionWatcher = () => {
 					networkStatus === networkStatusTypes.ONLINE ? '$success' : '$warning'
 				}
 			>
-				<Paragraph fontWeight={'$6'} textAlign='center' color='$background'>
+				<Paragraph fontWeight={'600'} textAlign='center' color='$background'>
 					{networkStatus === networkStatusTypes.ONLINE
 						? internetConnectionWatcher.BACK_ONLINE
 						: internetConnectionWatcher.NO_INTERNET}

--- a/src/components/Player/components/blurred-background.tsx
+++ b/src/components/Player/components/blurred-background.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { useTheme, View, YStack, ZStack } from 'tamagui'
 import { useWindowDimensions } from 'react-native'
+// NOTE: this file is the ONLY consumer of react-native-linear-gradient in the app.
+// react-native-svg is already a dependency and provides its own LinearGradient, so
+// porting these two gradients would drop a native module entirely. Low risk, small
+// win; note Reanimated has no gradient primitive, so svg is the target, not Reanimated.
 import LinearGradient from 'react-native-linear-gradient'
 import { Blurhash } from 'react-native-blurhash'
 import useIsLightMode from '../../../hooks/use-is-light-mode'

--- a/src/components/Player/components/header.tsx
+++ b/src/components/Player/components/header.tsx
@@ -11,7 +11,7 @@ import Animated, {
 	useSharedValue,
 	withSpring,
 } from 'react-native-reanimated'
-import { LayoutChangeEvent } from 'react-native'
+import { LayoutChangeEvent, View } from 'react-native'
 import MaterialDesignIcons from '@react-native-vector-icons/material-design-icons'
 import navigationRef from '../../../screens/navigation'
 import { useQueueRef, useCurrentTrack } from '../../../stores/player/queue'
@@ -107,23 +107,33 @@ function PlayerArtwork(): React.JSX.Element {
 			marginVertical={'auto'}
 			onLayout={handleLayout}
 		>
+			{/*
+			 * The GestureDetector must own exactly one, never-replaced child. The album art
+			 * below is keyed on the track ID and has an exiting animation, so on a track
+			 * change Reanimated briefly keeps the old view mounted while adding the new one.
+			 * Without this stable wrapper the detector sees two children and throws
+			 * "Cannot have more than one child view..." (react-native-gesture-handler 3.x).
+			 * collapsable={false} stops Android from flattening the wrapper away.
+			 */}
 			<GestureDetector gesture={albumCoverGesture}>
-				{nowPlaying && item && (
-					<Animated.View
-						entering={FadeIn.easing(Easing.in(Easing.ease))}
-						exiting={FadeOut.easing(Easing.out(Easing.ease))}
-						key={`${nowPlaying.id}-item-image`}
-						style={{
-							...animatedStyle,
-						}}
-					>
-						<ItemImage
-							item={item}
-							testID='player-image-test-id'
-							imageOptions={{ maxWidth: 800, maxHeight: 800 }}
-						/>
-					</Animated.View>
-				)}
+				<View collapsable={false}>
+					{nowPlaying && item && (
+						<Animated.View
+							entering={FadeIn.easing(Easing.in(Easing.ease))}
+							exiting={FadeOut.easing(Easing.out(Easing.ease))}
+							key={`${nowPlaying.id}-item-image`}
+							style={{
+								...animatedStyle,
+							}}
+						>
+							<ItemImage
+								item={item}
+								testID='player-image-test-id'
+								imageOptions={{ maxWidth: 800, maxHeight: 800 }}
+							/>
+						</Animated.View>
+					)}
+				</View>
 			</GestureDetector>
 		</YStack>
 	)

--- a/src/components/Player/components/scrubber.tsx
+++ b/src/components/Player/components/scrubber.tsx
@@ -95,7 +95,7 @@ export default function Scrubber({ onSeekComplete }: ScrubberProps = {}): React.
 			{/* Time display and quality badge */}
 			<XStack alignItems='center' justifyContent='space-between'>
 				<YStack flex={1}>
-					<Paragraph fontWeight={'$6'} textAlign={'left'} fontVariant={['tabular-nums']}>
+					<Paragraph fontWeight={'600'} textAlign={'left'} fontVariant={['tabular-nums']}>
 						{positionRunTimeText}
 					</Paragraph>
 				</YStack>

--- a/src/components/Player/components/song-info.tsx
+++ b/src/components/Player/components/song-info.tsx
@@ -88,7 +88,7 @@ export default function SongInfo(): React.JSX.Element {
 						key={`${currentTrack?.id ?? 'no-track'}-title`}
 					>
 						<Paragraph
-							fontWeight={'$6'}
+							fontWeight={'600'}
 							fontSize={'$6'}
 							onPress={handleTrackPress}
 							{...ICON_PRESS_STYLES}

--- a/src/components/Player/mini-player.tsx
+++ b/src/components/Player/mini-player.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import { View } from 'react-native'
 import { useTheme, XStack, YStack } from 'tamagui'
 import { useNavigation } from '@react-navigation/native'
 import { Text } from '../Global/helpers/text'
@@ -99,65 +100,72 @@ export default function Miniplayer(): React.JSX.Element | null {
 	const customBlurhash = typeof payload?.blurhash === 'string' ? payload.blurhash : undefined
 
 	return (
+		/*
+		 * Stable single child for the detector: the Animated.View below has an entering
+		 * animation, so Reanimated can add it while a previous instance is still mounted.
+		 * See the matching comment in Player/components/header.tsx.
+		 */
 		<GestureDetector gesture={gesture}>
-			<Animated.View
-				collapsable={false}
-				testID='miniplayer-test-id'
-				entering={SlideInDown.springify()}
-			>
-				<YStack
-					onPress={openPlayer}
-					backgroundColor={theme.background.val}
-					{...ICON_PRESS_STYLES}
+			<View collapsable={false}>
+				<Animated.View
+					collapsable={false}
+					testID='miniplayer-test-id'
+					entering={SlideInDown.springify()}
 				>
-					<MiniPlayerProgress />
-					<XStack alignItems='center' padding={'$2'}>
-						<YStack justify='center' alignItems='center'>
-							<Animated.View
-								entering={FadeIn.easing(Easing.in(Easing.ease))}
-								exiting={FadeOut.easing(Easing.out(Easing.ease))}
+					<YStack
+						onPress={openPlayer}
+						backgroundColor={theme.background.val}
+						{...ICON_PRESS_STYLES}
+					>
+						<MiniPlayerProgress />
+						<XStack alignItems='center' padding={'$2'}>
+							<YStack justify='center' alignItems='center'>
+								<Animated.View
+									entering={FadeIn.easing(Easing.in(Easing.ease))}
+									exiting={FadeOut.easing(Easing.out(Easing.ease))}
+								>
+									<ItemImage
+										key={item.AlbumId} // Without this, a failed image load means all image loading stops
+										item={item!}
+										customBlurhash={customBlurhash}
+										width={'$3'}
+										height={'$3'}
+										imageOptions={{ maxWidth: 120, maxHeight: 120 }}
+										elevate
+									/>
+								</Animated.View>
+							</YStack>
+
+							<YStack
+								alignContent='flex-start'
+								justifyContent='center'
+								marginHorizontal={'$2'}
+								flex={1}
 							>
-								<ItemImage
-									key={item.AlbumId} // Without this, a failed image load means all image loading stops
-									item={item!}
-									customBlurhash={customBlurhash}
-									width={'$3'}
-									height={'$3'}
-									imageOptions={{ maxWidth: 120, maxHeight: 120 }}
-									elevate
-								/>
-							</Animated.View>
-						</YStack>
+								<Animated.View
+									entering={FadeIn.easing(Easing.in(Easing.ease))}
+									exiting={FadeOut.easing(Easing.out(Easing.ease))}
+									key={`${nowPlaying!.id}-mini-player-song-info`}
+								>
+									<TextTicker {...TextTickerConfig}>
+										<Text bold>{nowPlaying.title ?? 'Nothing Playing'}</Text>
+									</TextTicker>
 
-						<YStack
-							alignContent='flex-start'
-							justifyContent='center'
-							marginHorizontal={'$2'}
-							flex={1}
-						>
-							<Animated.View
-								entering={FadeIn.easing(Easing.in(Easing.ease))}
-								exiting={FadeOut.easing(Easing.out(Easing.ease))}
-								key={`${nowPlaying!.id}-mini-player-song-info`}
-							>
-								<TextTicker {...TextTickerConfig}>
-									<Text bold>{nowPlaying.title ?? 'Nothing Playing'}</Text>
-								</TextTicker>
+									<TextTicker {...TextTickerConfig}>
+										<Text height={'$0.5'}>
+											{nowPlaying.artist ?? 'Unknown Artist'}
+										</Text>
+									</TextTicker>
+								</Animated.View>
+							</YStack>
 
-								<TextTicker {...TextTickerConfig}>
-									<Text height={'$0.5'}>
-										{nowPlaying.artist ?? 'Unknown Artist'}
-									</Text>
-								</TextTicker>
-							</Animated.View>
-						</YStack>
-
-						<XStack justifyContent='center' alignItems='center' flexShrink={1}>
-							<PlayPauseIcon />
+							<XStack justifyContent='center' alignItems='center' flexShrink={1}>
+								<PlayPauseIcon />
+							</XStack>
 						</XStack>
-					</XStack>
-				</YStack>
-			</Animated.View>
+					</YStack>
+				</Animated.View>
+			</View>
 		</GestureDetector>
 	)
 }

--- a/src/components/Queue/components/header.tsx
+++ b/src/components/Queue/components/header.tsx
@@ -41,7 +41,7 @@ export default function QueueListHeader() {
 					alignSelf='center'
 				/>
 
-				<Paragraph fontWeight={'$6'} fontSize={'$4'} textAlign='center'>
+				<Paragraph fontWeight={'600'} fontSize={'$4'} textAlign='center'>
 					Now Playing
 				</Paragraph>
 			</YStack>

--- a/src/components/Queue/index.tsx
+++ b/src/components/Queue/index.tsx
@@ -2,6 +2,12 @@ import { useCurrentIndex, usePlayQueue } from '../../stores/player/queue'
 import { TrackItem } from 'react-native-nitro-player'
 import { ListRenderItemInfo, Platform } from 'react-native'
 import { useSafeAreaFrame, useSafeAreaInsets } from 'react-native-safe-area-context'
+// NOTE: react-native-drax@1.1.0 declares `react-native-gesture-handler: ">=2.0.0"` and
+// has no stated support for RNGH 3.x, which this app runs. RNGH 3 was a major rewrite
+// (its new RNGestureHandlerDetectorView is what threw the "more than one child view"
+// assertion fixed in Player/components/header.tsx). A gesture-heavy library sitting on
+// an unsupported major is a plausible source of further drag-and-drop bugs here and in
+// Playlist/index.tsx. Worth verifying against RNGH 3 or replacing.
 import { DraxList, DraxProvider, SortableReorderEvent } from 'react-native-drax'
 import QueuedTrack from './components/track'
 import { itemDraxViewProps } from '../../configs/styling/drax'

--- a/src/components/Settings/components/settings/send-metrics-and-crash-data.tsx
+++ b/src/components/Settings/components/settings/send-metrics-and-crash-data.tsx
@@ -8,7 +8,7 @@ export default function SendMetricsAndCrashDataSetting(): React.JSX.Element {
 	return (
 		<XStack alignItems='center' justifyContent='space-between'>
 			<YStack flex={1}>
-				<SizableText size='$4' fontWeight={'$6'}>
+				<SizableText size='$4' fontWeight={'600'}>
 					Send Analytics
 				</SizableText>
 				<SizableText size='$2' color='$borderColor'>

--- a/src/components/Settings/components/vertical-settings.tsx
+++ b/src/components/Settings/components/vertical-settings.tsx
@@ -55,7 +55,7 @@ export default function VerticalSettings(): React.JSX.Element {
 							</Avatar.Fallback>
 						</Avatar>
 						<YStack flex={1}>
-							<SizableText size='$6' fontWeight='$6' color='$background'>
+							<SizableText size='$6' fontWeight='600' color='$background'>
 								{user?.name ?? 'Unknown User'}
 							</SizableText>
 							<XStack alignItems='center' gap='$1.5'>
@@ -125,7 +125,7 @@ export default function VerticalSettings(): React.JSX.Element {
 						onPress={() => navigation.navigate('SignOut')}
 						icon={<Icon name='logout' color='$background' />}
 					>
-						<Paragraph color='$background' fontWeight='$6'>
+						<Paragraph color='$background' fontWeight='600'>
 							Sign Out
 						</Paragraph>
 					</Button>

--- a/src/configs/axios.config.ts
+++ b/src/configs/axios.config.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// NOTE: axios and react-native-nitro-fetch are both dependencies on purpose, not by
+// accident. The Jellyfin SDK requires an axios instance, and the adapter below routes
+// axios through nitro-fetch's native implementation. Do not "deduplicate" these.
 import axios, {
 	AxiosAdapter,
 	AxiosError,

--- a/src/configs/styling/fonts.ts
+++ b/src/configs/styling/fonts.ts
@@ -25,9 +25,13 @@ const figtreeFace = {
 /**
  * Weight tokens ($1-$10) mapped to CSS numeric weights.
  *
- * This scale must be dense. A gap means `fontWeight='$8'` finds nothing in the weight
- * scale and resolves against a different token scale instead, yielding a nonsense
- * value like `fontWeight: 32` that Android rejects.
+ * Note that this scale does NOT make `fontWeight='$6'` safe to use in components.
+ * Because this app drives Tamagui animations with Reanimated, a weight token on an
+ * animated component never reaches this scale — it resolves against the space scale
+ * ('$6' is 32) and Reanimated then throws "Invalid font weight value: 32".
+ * Always pass literal weight strings in components; see Global/helpers/text.tsx.
+ *
+ * This scale is kept dense and correct for the non-animated paths that do consult it.
  */
 const figtreeWeight = {
 	1: '300',

--- a/src/configs/styling/fonts.ts
+++ b/src/configs/styling/fonts.ts
@@ -1,27 +1,52 @@
 import { fonts } from '@tamagui/config/v4'
 import { createFont } from 'tamagui'
 
+/**
+ * Maps a CSS numeric font weight to the Figtree file that actually implements it.
+ *
+ * Every name here must match a file in assets/fonts/ exactly (minus the extension) —
+ * Android resolves fontFamily by asset filename, so a name that does not match falls
+ * back to the system font, and on Fabric can fail outright rather than degrade.
+ *
+ * Figtree ships no Thin or ExtraLight cut, so 100/200 reuse Light.
+ */
 const figtreeFace = {
-	100: { normal: 'Figtree-Light', italic: 'Figtree Light Italic' },
-	200: { normal: 'Figtree-Light', italic: 'Figtree Light Italic' },
-	300: { normal: 'Figtree-Regular', italic: 'Figtree Italic' },
-	400: { normal: 'Figtree-Medium', italic: 'Figtree Medium Italic' },
-	500: { normal: 'Figtree-SemiBold', italic: 'Figtree SemiBold Italic' },
-	600: { normal: 'Figtree-Bold', italic: 'Figtree Bold Italic' },
-	700: { normal: 'Figtree-ExtraBold', italic: 'Figtree ExtraBold Italic' },
-	800: { normal: 'Figtree-Black', italic: 'Figtree Black Italic' },
-	900: { normal: 'Figtree-Black', italic: 'Figtree Black Italic' },
+	100: { normal: 'Figtree-Light', italic: 'Figtree-LightItalic' },
+	200: { normal: 'Figtree-Light', italic: 'Figtree-LightItalic' },
+	300: { normal: 'Figtree-Light', italic: 'Figtree-LightItalic' },
+	400: { normal: 'Figtree-Regular', italic: 'Figtree-Italic' },
+	500: { normal: 'Figtree-Medium', italic: 'Figtree-MediumItalic' },
+	600: { normal: 'Figtree-SemiBold', italic: 'Figtree-SemiBoldItalic' },
+	700: { normal: 'Figtree-Bold', italic: 'Figtree-BoldItalic' },
+	800: { normal: 'Figtree-ExtraBold', italic: 'Figtree-ExtraBoldItalic' },
+	900: { normal: 'Figtree-Black', italic: 'Figtree-BlackItalic' },
+}
+
+/**
+ * Weight tokens ($1-$10) mapped to CSS numeric weights.
+ *
+ * This scale must be dense. A gap means `fontWeight='$8'` finds nothing in the weight
+ * scale and resolves against a different token scale instead, yielding a nonsense
+ * value like `fontWeight: 32` that Android rejects.
+ */
+const figtreeWeight = {
+	1: '300',
+	2: '300',
+	3: '300',
+	4: '400',
+	5: '500',
+	6: '600',
+	7: '700',
+	8: '800',
+	9: '900',
+	10: '900',
 }
 
 export const bodyFont = createFont({
 	family: 'Figtree',
 	size: fonts.body.size,
 	lineHeight: fonts.body.lineHeight,
-	weight: {
-		4: '300',
-		6: '600',
-		8: '900',
-	},
+	weight: figtreeWeight,
 	letterSpacing: fonts.body.letterSpacing,
 	face: figtreeFace,
 })
@@ -30,11 +55,7 @@ export const headingFont = createFont({
 	family: 'Figtree',
 	size: fonts.heading.size,
 	lineHeight: fonts.heading.lineHeight,
-	weight: {
-		4: '300',
-		6: '600',
-		8: '900',
-	},
+	weight: figtreeWeight,
 	letterSpacing: fonts.heading.letterSpacing,
 	face: figtreeFace,
 })

--- a/src/hooks/use-performance-monitor.ts
+++ b/src/hooks/use-performance-monitor.ts
@@ -17,6 +17,18 @@ const EMPTY_METRICS: PerformanceMetrics = {
 
 /**
  * Hook to monitor component performance and detect excessive re-renders
+ *
+ * WARNING: never call this from a list item or any component rendered many times.
+ *
+ * In dev it schedules an effect on *every* render and reduces over its samples on
+ * every render. Worse, when a component exceeds `threshold` it calls console.warn —
+ * and in a debug build every console call is routed through LogBox's addLog and
+ * shipped to Metro over the websocket, which is expensive. One instance is fine;
+ * a few hundred list items each warning will visibly stall the JS thread, so the
+ * monitoring itself becomes the performance problem it is meant to detect.
+ *
+ * Suitable call sites are single-instance components (App, a screen root).
+ *
  * @param componentName - Name of the component for logging
  * @param threshold - Number of renders before warning (default: 10)
  * @returns Performance metrics object

--- a/src/screens/GenreSelection/index.tsx
+++ b/src/screens/GenreSelection/index.tsx
@@ -245,7 +245,7 @@ export default function GenreSelectionScreen(): React.JSX.Element {
 						size='$3'
 						onPress={handleSave}
 					>
-						<Paragraph fontWeight={'$6'} color={'$primary'}>
+						<Paragraph fontWeight={'600'} color={'$primary'}>
 							Apply
 						</Paragraph>
 					</Button>

--- a/src/screens/MigrateDownloads/index.tsx
+++ b/src/screens/MigrateDownloads/index.tsx
@@ -56,11 +56,11 @@ export default function MigrateDownloadsScreen({
 			marginHorizontal={'$4'}
 			gap={'$4'}
 		>
-			<Paragraph textAlign='center' fontSize={'$8'} fontWeight='$6'>
+			<Paragraph textAlign='center' fontSize={'$8'} fontWeight='600'>
 				There are some downloads from a previous version of Jellify
 			</Paragraph>
 
-			<Paragraph textAlign='center' fontSize={'$6'} fontWeight={'$6'}>
+			<Paragraph textAlign='center' fontSize={'$6'} fontWeight={'600'}>
 				Would you like to migrate them?
 			</Paragraph>
 

--- a/src/screens/Settings/about.tsx
+++ b/src/screens/Settings/about.tsx
@@ -67,7 +67,7 @@ export default function AboutScreen(): React.JSX.Element {
 					<YStack gap='$1'>
 						<XStack alignItems='center' gap='$2' testID='jellify-version-text'>
 							<Icon name='jellyfish' color='$primary' />
-							<SizableText size='$6' fontWeight='$6'>
+							<SizableText size='$6' fontWeight='600'>
 								Jellify {version}
 							</SizableText>
 						</XStack>
@@ -200,7 +200,7 @@ export default function AboutScreen(): React.JSX.Element {
 					borderWidth={'$1'}
 				>
 					<YStack gap='$1'>
-						<SizableText size='$4' fontWeight='$6'>
+						<SizableText size='$4' fontWeight='600'>
 							Special Thanks
 						</SizableText>
 						<SpecialThanksList />

--- a/src/screens/Settings/account.tsx
+++ b/src/screens/Settings/account.tsx
@@ -49,7 +49,7 @@ export default function AccountScreen(): React.JSX.Element {
 							</Avatar.Fallback>
 						</Avatar>
 						<YStack alignItems='center' gap='$1'>
-							<SizableText size='$7' fontWeight='$6' color='$background'>
+							<SizableText size='$7' fontWeight='600' color='$background'>
 								{user?.name ?? 'Unknown User'}
 							</SizableText>
 							<SizableText size='$3' color='$background'>
@@ -86,7 +86,7 @@ export default function AccountScreen(): React.JSX.Element {
 								<Icon name='music-box-multiple' color='$background' small />
 							</YStack>
 							<YStack flex={1}>
-								<SizableText size='$4' fontWeight='$6'>
+								<SizableText size='$4' fontWeight='600'>
 									{library?.musicLibraryName ?? 'Unknown Library'}
 								</SizableText>
 								<SizableText size='$2' color='$borderColor'>

--- a/src/screens/Settings/appearance.tsx
+++ b/src/screens/Settings/appearance.tsx
@@ -122,7 +122,7 @@ export default function AppearanceScreen(): React.JSX.Element {
 			>
 				<YStack padding='$4' gap='$6'>
 					<YStack gap='$3'>
-						<SizableText size='$4' fontWeight='$6'>
+						<SizableText size='$4' fontWeight='600'>
 							Theme
 						</SizableText>
 						<XStack flexWrap='wrap' gap='$2'>
@@ -138,7 +138,7 @@ export default function AppearanceScreen(): React.JSX.Element {
 					</YStack>
 
 					<YStack gap='$3'>
-						<SizableText size='$4' fontWeight='$6'>
+						<SizableText size='$4' fontWeight='600'>
 							Color Scheme
 						</SizableText>
 						<XStack flexWrap='wrap' gap='$2'>
@@ -155,7 +155,7 @@ export default function AppearanceScreen(): React.JSX.Element {
 
 					<XStack alignItems='center' justifyContent='space-between'>
 						<YStack flex={1}>
-							<SizableText size='$4' fontWeight='$6'>
+							<SizableText size='$4' fontWeight='600'>
 								Hide Runtimes
 							</SizableText>
 							<SizableText size='$2' color='$borderColor'>
@@ -171,7 +171,7 @@ export default function AppearanceScreen(): React.JSX.Element {
 
 					<XStack alignItems='center' justifyContent='space-between'>
 						<YStack flex={1}>
-							<SizableText size='$4' fontWeight='$6'>
+							<SizableText size='$4' fontWeight='600'>
 								Hide Card Indicators
 							</SizableText>
 							<SizableText size='$2' color='$borderColor'>

--- a/src/screens/Settings/playback.tsx
+++ b/src/screens/Settings/playback.tsx
@@ -73,7 +73,7 @@ export default function PlaybackScreen(): React.JSX.Element {
 				>
 					<YStack gap='$3'>
 						<YStack gap='$1'>
-							<SizableText size='$4' fontWeight='$6'>
+							<SizableText size='$4' fontWeight='600'>
 								Streaming Quality
 							</SizableText>
 							<SizableText size='$2' color='$borderColor'>
@@ -111,7 +111,7 @@ export default function PlaybackScreen(): React.JSX.Element {
 
 					<XStack alignItems='center' justifyContent='space-between'>
 						<YStack flex={1}>
-							<SizableText size='$4' fontWeight='$6'>
+							<SizableText size='$4' fontWeight='600'>
 								Audio Normalization
 							</SizableText>
 							<SizableText size='$2' color='$borderColor'>
@@ -127,7 +127,7 @@ export default function PlaybackScreen(): React.JSX.Element {
 
 					<XStack alignItems='center' justifyContent='space-between'>
 						<YStack flex={1}>
-							<SizableText size='$4' fontWeight='$6'>
+							<SizableText size='$4' fontWeight='600'>
 								Quality Badge
 							</SizableText>
 							<SizableText size='$2' color='$borderColor'>
@@ -144,7 +144,7 @@ export default function PlaybackScreen(): React.JSX.Element {
 					<YStack alignItems='flex-start' gap='$3'>
 						<XStack alignItems='center' justifyContent='space-between' width='100%'>
 							<YStack flex={1}>
-								<SizableText size='$4' fontWeight='$6'>
+								<SizableText size='$4' fontWeight='600'>
 									Track Lookahead
 								</SizableText>
 								<SizableText size='$2' color='$borderColor'>
@@ -154,7 +154,7 @@ export default function PlaybackScreen(): React.JSX.Element {
 
 							<SizableText
 								size='$4'
-								fontWeight={'$6'}
+								fontWeight={'600'}
 								fontVariant={['tabular-nums']}
 								color='$borderColor'
 							>

--- a/src/screens/Settings/privacy-developer.tsx
+++ b/src/screens/Settings/privacy-developer.tsx
@@ -52,7 +52,7 @@ export default function PrivacyDeveloperScreen(): React.JSX.Element {
 
 					<XStack alignItems='center' justifyContent='space-between'>
 						<YStack flex={1}>
-							<SizableText size='$4' fontWeight={'$6'}>
+							<SizableText size='$4' fontWeight={'600'}>
 								Reduce Haptics
 							</SizableText>
 							<SizableText size='$2' color='$borderColor'>
@@ -76,7 +76,7 @@ export default function PrivacyDeveloperScreen(): React.JSX.Element {
 				>
 					<XStack alignItems='center' justifyContent='space-between'>
 						<YStack flex={1}>
-							<SizableText size='$4' fontWeight='$6'>
+							<SizableText size='$4' fontWeight='600'>
 								Developer Options
 							</SizableText>
 							<SizableText size='$2' color='$borderColor'>

--- a/src/screens/Settings/storage-selection-modal.tsx
+++ b/src/screens/Settings/storage-selection-modal.tsx
@@ -119,7 +119,7 @@ export default function StorageSelectionModal({
 						disabled={isDeleting}
 						backgroundColor='$danger'
 					>
-						<Paragraph fontWeight={'$6'} color={'$background'}>
+						<Paragraph fontWeight={'600'} color={'$background'}>
 							Delete downloads
 						</Paragraph>
 					</Button>

--- a/src/screens/Storage/index.tsx
+++ b/src/screens/Storage/index.tsx
@@ -265,7 +265,7 @@ const StorageSummaryCard = ({
 						onPress={onDeleteAll}
 						icon={() => <Icon name='broom' color='$background' small />}
 					>
-						<Paragraph fontWeight={'$6'} color={'$background'}>
+						<Paragraph fontWeight={'600'} color={'$background'}>
 							Clear All
 						</Paragraph>
 					</Button>
@@ -362,7 +362,7 @@ const CleanupSuggestionsRow = ({
 								}
 								onPress={() => onApply(suggestion)}
 							>
-								<Paragraph fontWeight={'$6'} color={'$background'}>
+								<Paragraph fontWeight={'600'} color={'$background'}>
 									Free {formatBytes(suggestion.freedBytes)}
 								</Paragraph>
 							</Button>
@@ -504,7 +504,7 @@ const SelectionReviewBanner = ({
 				onPress={onDelete}
 			>
 				<Paragraph
-					fontWeight={'$6'}
+					fontWeight={'600'}
 					color={'$warning'}
 				>{`Clear ${formatBytes(selectedBytes)}`}</Paragraph>
 			</Button>

--- a/src/screens/YearSelection/index.tsx
+++ b/src/screens/YearSelection/index.tsx
@@ -280,7 +280,7 @@ export default function YearSelectionScreen({ route }: YearSelectionProps): Reac
 						size='$3'
 						onPress={handleSave}
 					>
-						<Paragraph color={'$primary'} fontWeight={'$6'}>
+						<Paragraph color={'$primary'} fontWeight={'600'}>
 							Apply
 						</Paragraph>
 					</Button>

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -125,14 +125,14 @@ function ContextSheetHeader(item: BaseItemDto): React.JSX.Element {
 	return (
 		<YStack gap={'$1'} marginTop={'$4'} alignItems='center'>
 			<TextTicker {...TextTickerConfig}>
-				<Paragraph fontWeight={'$6'} fontSize={'$6'}>
+				<Paragraph fontWeight={'600'} fontSize={'$6'}>
 					{getItemName(item)}
 				</Paragraph>
 			</TextTicker>
 
 			{(item.ArtistItems?.length ?? 0) > 0 && (
 				<TextTicker {...TextTickerConfig}>
-					<Paragraph fontWeight={'$6'} fontSize={'$4'}>
+					<Paragraph fontWeight={'600'} fontSize={'$4'}>
 						{`${formatArtistNames(item.ArtistItems?.map((artist) => getItemName(artist)) ?? [])}`}
 					</Paragraph>
 				</TextTicker>

--- a/src/utils/console-override.ts
+++ b/src/utils/console-override.ts
@@ -50,5 +50,17 @@ export const initializeConsoleOverride = () => {
 	// In development (__DEV__ = true), console methods remain unchanged
 }
 
+/*
+ * DEBUGGING CAVEAT: because console.error and console.warn are no-ops in release
+ * builds, a JavaScript error that only reproduces in release produces no output at
+ * all — the app just dies silently. This actively obstructed diagnosing the
+ * "Invalid font weight value: 32" launch crash, which was invisible here and only
+ * became findable via `adb logcat -b crash -d` because it surfaced as a native
+ * exception.
+ *
+ * When chasing a release-only bug, temporarily comment out the call to
+ * initializeConsoleOverride() below so JS errors reach logcat.
+ */
+
 // Auto-initialize when this module is imported
 initializeConsoleOverride()


### PR DESCRIPTION
### What is the change
**Three independent Android bug fixes, one per commit**:
1. `fix: correct Figtree weight tokens and font face mapping` — corrects the weight→face map in `src/configs/styling/fonts.ts` and fills the weight token scale out to `$1`–`$10`.
2. `fix: prevent crash on track change from gesture detector child count` — wraps the animated subtrees inside `GestureDetector` in the player header and mini player with a stable, non-collapsible `View`.
3. `fix: return null from lyrics fetch when a track has no lyrics` — `fetchRawLyrics` now returns `null` instead of `undefined`.

### What does this address
**1. Invalid fontWeight values from unresolvable weight tokens**
- The weight scale defined only `$4`, `$6` and `$8`. A weight token with no entry falls through and resolves against a different token scale, producing values such as `fontWeight: 32`, which is not a legal CSS weight. On the new architecture this surfaced as a crash on the library selector (`fontWeight={isSelected ? '$8' : 'unset'}`) rather than a silent fallback. Filling the scale to `$1`–`$10` means no token can miss.
- Separately, the face map was shifted one step heavy from 300 upward — 400 resolved to `Figtree-Medium`, 600 to `Figtree-Bold`, 800 to `Figtree-Black`. Every italic entry also used spaces rather than hyphens ('Figtree Bold Italic' instead of 'Figtree-BoldItalic'). Since Android resolves `fontFamily` by asset filename, no italic face has ever matched a bundled font — all italics silently fell back to the system typeface.
- Note this slightly lightens text at `$6` and `$8`, which is the corrected weight rather than a regression.

**2. Crash on every next-track press (Android)**
- `react-native-gesture-handler` 3.x asserts that a `GestureDetector` owns exactly one child view when native handlers are attached (`RNGestureHandlerDetectorView.addView`, line 73). Reanimated's `exiting` layout animations intentionally keep the outgoing view mounted while the incoming one is added, so an animated direct child briefly gives the detector two children:
`java.lang.AssertionError: Cannot have more than one child view when native
gesture handlers are attached to the detector 
     at com.swmansion.gesturehandler.react.RNGestureHandlerDetectorView.addView(RNGestureHandlerDetectorView.kt:73)
     at com.facebook.react.fabric.mounting.SurfaceMountingManager.addViewAt(SurfaceMountingManager.kt:381)
     ...
     at com.swmansion.reanimated.NativeProxy.performOperations(Native Method)`
- In `Player/components/header.tsx`, the album art is conditional, keyed on the track ID, and has both `entering` and `exiting` animations — so this reproduced on every next-track press. The dispatch originating from `NativeProxy.performOperations` rather than React's commit path is what identifies it as the layout animation rather than an ordinary re-render.
- Wrapping the animated subtree in a stable `View` gives the detector a single child that is never replaced; the animation swap now happens one level below it. `collapsable={false}` is required so Android's view flattening doesn't remove the wrapper again. The mini player has the same pattern with an `entering` animation and is fixed identically. The other five `GestureDetector` call sites already wrap their animated content in a stable parent and are untouched.
- One caveat worth flagging: Kotlin's `assert` is gated on `Class.desiredAssertionStatus()`, so this hard crash may only surface in debuggable builds. The underlying condition — native handlers attaching to a transient child — is a real defect regardless of whether the assertion fires.

3. `Query data cannot be undefined` on tracks without lyrics 
- `fetchRawLyrics` returned `undefined` both on request failure and when the server responded without a `Lyrics` field. TanStack Query rejects `undefined` as a result, logging `Query data cannot be undefined. Affected query key: ["TRACK_LYRICS", ...]` and leaving the query unresolved — so any track without lyrics produced a console error on every play.

Testing
- `bun tsc` — 0 errors
- `bun lint` — 0 errors
- `bun format:check` — clean
- `bun test` — 122/122 passing
- Manually verified on a Pixel 9 (LineageOS, Android 16): next-track no longer crashes, and the screens using `$6/$8` weight tokens render correctly with tokens restored.

### Issue number / link
**Issue**: #1415 
**Link**: https://github.com/Jellify-Music/App/issues/1415 
**This person had the same issue also on their Pixel 11**. My issue was on a Pixel 9; this PR could solve both issues: 
**Issue**: #1413 
**Link**: https://github.com/Jellify-Music/App/issues/1413

### Tag reviewers
**@anultravioletaurora**