### PR TITLE
Implement faster pagination for library

### DIFF
--- a/src/api/queries/README.md
+++ b/src/api/queries/README.md
@@ -1,0 +1,65 @@
+# queries
+
+This folder contains all React Query hooks used to fetch data from the Jellyfin server. Each subfolder covers one domain entity (`artist`, `album`, `track`, `genre`, `playlist`, etc.) and follows the same internal structure.
+
+**Relevant docs:**
+- [TanStack Query — Queries](https://tanstack.com/query/latest/docs/framework/react/guides/queries)
+- [TanStack Query — Infinite Queries](https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries)
+
+---
+
+## Folder structure
+
+Each entity folder is organized in layers, from the hook consumed by components down to the raw HTTP call:
+
+| File | Description |
+|---|---|
+| `index.ts` | **Hooks.** The only exports components should import (e.g. `useAlbumArtists`, `useAlbums`, `useTracks`). Wraps `useQuery`/`useInfiniteQuery`, reads any required state (filters, sort, library) from stores, and wires it into a `queryFn` |
+| `keys.ts` | Query key builder functions (e.g. `ArtistQueryKey`, `TracksQueryKey`). Centralizing key construction here means the same key can be reused elsewhere for cache reads/writes (`queryClient.getQueryData`, `queryClient.setQueryData`, invalidation, etc.) |
+| `queries.ts` | *(optional)* Plain query-option objects shared by more than one hook or reused outside of a component (e.g. prefetching). Not every entity needs this layer |
+| `utils/` | **Fetch functions.** Plain async functions that call the Jellyfin SDK (`getItemsApi`, `getArtistsApi`, etc.) directly and return plain data (`BaseItemDto[]`, etc.). These have no knowledge of React Query — they just take explicit params (api, user, library, page, filters, signal) and resolve/reject a promise |
+
+The hook is the only layer that talks to React Query; everything below `index.ts` is framework-agnostic and could be called imperatively (which is exactly what the letter-cursor jump described below does).
+
+A couple of folders are exceptions to this pattern:
+- `item.ts` — generic single-item fetch/query helpers shared across entities, kept flat since it isn't its own domain
+- `image/` — only has a `utils/` layer since it exposes fetch helpers, not hooks
+
+---
+
+## Infinite queries
+
+List screens (artists, albums, tracks, genres, etc.) use `useInfiniteQuery` with a numeric `pageParam` that represents a page index, not an item offset:
+
+```ts
+queryFn: ({ pageParam, signal }) =>
+  fetchArtists(user, library, pageParam, isFavorite, sortBy, sortOrder, signal),
+getNextPageParam: (lastPage, allPages, lastPageParam) =>
+  lastPage.length === ApiLimits.Library ? lastPageParam + 1 : undefined,
+```
+
+- **`ApiLimits`** ([configs/querying/index.config.ts](../../configs/querying/index.config.ts)) defines the page size per entity (e.g. `ApiLimits.Library`). The fetch util converts `pageParam` into a real offset: `startIndex: pageParam * ApiLimits.Library`
+- **`MaxPages`** caps how many pages are kept in the query's cache at once (via the `maxPages` option); older pages are dropped as new ones are fetched, keeping memory bounded on long lists
+- `select` commonly flattens `InfiniteData` pages into a single array (`flattenInfiniteQueryPages`), optionally grouping items into `LibrarySectionListData[]` sections for an A-Z section list
+
+### Letter cursor (A-Z scroller jump)
+
+The A-Z scroller (`components/Global/components/AZScroller`) needs to jump straight to the page containing a tapped letter instead of paginating through every page in between. `fetchNextPage` in TanStack Query only supports fetching forward/backward from the last known page, so entities that back a section list also build a [`LetterCursor`](../../types/LetterCursor.ts) and attach it to the query result:
+
+```ts
+const query = useInfiniteQuery({ queryKey, ... })
+
+const letterCursor: LetterCursor = {
+  queryKey,
+  fetchPage: (page, signal) => fetchArtists(user, library, page, ...),
+  countBeforeLetter: (letter, signal) => fetchArtistsCountBeforeLetter(user, library, letter, ...),
+}
+
+return Object.assign(query, { letterCursor })
+```
+
+- `countBeforeLetter` asks the Jellyfin API for the exact number of items sorted before a given letter, using `nameLessThan` + `enableTotalRecordCount` with `limit: 1` — a single lightweight request instead of walking pages one by one
+- The page containing that letter is then `Math.floor(itemsBeforeLetter / ApiLimits.Library)`
+- `fetchPage` fetches that one page directly, and the result is merged into the query's cache with `queryClient.setQueryData` (see [AZScroller/utils.ts](../../components/Global/components/AZScroller/utils.ts)), trimming to `MaxPages.Library` the same way react-query's own `maxPages` option would
+
+Because `letterCursor` is just attached to the existing query object, components pass the query through unchanged and the section list/scroller widen their prop types to `UseInfiniteQueryResult<...> & { letterCursor: LetterCursor }` where needed.

--- a/src/api/queries/album/index.ts
+++ b/src/api/queries/album/index.ts
@@ -2,7 +2,7 @@ import { QueryKeys } from '../../../enums/query-keys'
 import { InfiniteData, useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by'
 import { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order'
-import { fetchAlbums } from './utils/album'
+import { fetchAlbums, fetchAlbumsCountBeforeLetter } from './utils/album'
 import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client'
 import flattenInfiniteQueryPages from '../../../utils/query-selectors'
 import { ApiLimits, MaxPages } from '../../../configs/querying/index.config'
@@ -14,6 +14,7 @@ import { fetchAlbumDiscs } from '../item'
 import { Api } from '@jellyfin/sdk/lib/api'
 import { AlbumDiscsQueryKey } from './keys'
 import { AlbumQuery, RecentlyAddedQuery } from './queries'
+import { LetterCursor } from '../../../types/LetterCursor'
 
 export const useAlbum = (album: BaseItemDto) => useQuery(AlbumQuery(album))
 
@@ -56,16 +57,18 @@ const useAlbums = () => {
 		return flattenInfiniteQueryPages(data)
 	}
 
-	return useInfiniteQuery({
-		queryKey: [
-			QueryKeys.InfiniteAlbums,
-			isFavorites,
-			library?.musicLibraryId,
-			librarySortBy,
-			sortDescending,
-			yearMin,
-			yearMax,
-		],
+	const queryKey = [
+		QueryKeys.InfiniteAlbums,
+		isFavorites,
+		library?.musicLibraryId,
+		librarySortBy,
+		sortDescending,
+		yearMin,
+		yearMax,
+	]
+
+	const query = useInfiniteQuery({
+		queryKey,
 		queryFn: ({ pageParam, signal }) =>
 			fetchAlbums(
 				api,
@@ -89,6 +92,37 @@ const useAlbums = () => {
 			return firstPageParam === 0 ? null : firstPageParam - 1
 		},
 	})
+
+	// Lets the A-Z scroller jump straight to the page containing a given letter
+	const letterCursor: LetterCursor = {
+		queryKey,
+		fetchPage: (page, signal) =>
+			fetchAlbums(
+				api,
+				user,
+				library,
+				page,
+				isFavorites,
+				[librarySortBy ?? ItemSortBy.SortName],
+				[sortDescending ? SortOrder.Descending : SortOrder.Ascending],
+				yearMin,
+				yearMax,
+				signal,
+			),
+		countBeforeLetter: (letter, signal) =>
+			fetchAlbumsCountBeforeLetter(
+				api,
+				user,
+				library,
+				letter,
+				isFavorites,
+				yearMin,
+				yearMax,
+				signal,
+			),
+	}
+
+	return Object.assign(query, { letterCursor })
 }
 
 export default useAlbums

--- a/src/api/queries/album/utils/album.ts
+++ b/src/api/queries/album/utils/album.ts
@@ -65,6 +65,63 @@ export function fetchAlbums(
 	})
 }
 
+/**
+ * Resolves the number of albums sorted before the given letter, so the A-Z
+ * scroller can compute which page that letter falls on without paginating
+ * through every page in between
+ * @param api The Jellyfin API instance
+ * @param user The user requesting the count
+ * @param library The library to count albums from
+ * @param letter The letter to count albums before
+ * @param isFavorite Whether to only count favorited albums
+ * @param yearMin Optional minimum year filter
+ * @param yearMax Optional maximum year filter
+ * @param signal Optional AbortSignal to cancel the request
+ * @returns A promise that resolves to the number of albums sorted before the letter
+ */
+export function fetchAlbumsCountBeforeLetter(
+	api: Api | undefined,
+	user: JellifyUser | undefined,
+	library: JellifyLibrary | undefined,
+	letter: string,
+	isFavorite: boolean | undefined,
+	yearMin?: number,
+	yearMax?: number,
+	signal?: AbortSignal,
+): Promise<number> {
+	return new Promise((resolve, reject) => {
+		if (!api) return reject('No API instance provided')
+		if (!user) return reject('No user provided')
+		if (!library) return reject('Library has not been set')
+
+		// '#' is the first section in the alphabet selector, so nothing precedes it
+		if (letter === '#') return resolve(0)
+
+		const yearsParam = buildYearsParam(yearMin, yearMax)
+
+		getItemsApi(api)
+			.getItems(
+				{
+					parentId: library.musicLibraryId,
+					includeItemTypes: [BaseItemKind.MusicAlbum],
+					userId: user.id,
+					nameLessThan: letter,
+					startIndex: 0,
+					limit: 1,
+					isFavorite: isFavorite,
+					recursive: true,
+					years: yearsParam,
+					enableTotalRecordCount: true,
+				},
+				{
+					signal,
+				},
+			)
+			.then(({ data }) => resolve(data.TotalRecordCount ?? 0))
+			.catch((error) => reject(error))
+	})
+}
+
 export function fetchAlbumById(
 	api: Api | undefined,
 	albumId: string,

--- a/src/api/queries/artist/index.ts
+++ b/src/api/queries/artist/index.ts
@@ -2,7 +2,7 @@ import { QueryKeys } from '../../../enums/query-keys'
 import { BaseItemDto, ItemSortBy, SortOrder } from '@jellyfin/sdk/lib/generated-client'
 import { InfiniteData, useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { isUndefined } from 'lodash'
-import { fetchArtistFeaturedOn, fetchArtists } from './utils/artist'
+import { fetchArtistFeaturedOn, fetchArtists, fetchArtistsCountBeforeLetter } from './utils/artist'
 import { ApiLimits, MaxPages } from '../../../configs/querying/index.config'
 import flattenInfiniteQueryPages from '../../../utils/query-selectors'
 import { useJellifyLibrary, useJellifyUser } from '../../../stores/auth'
@@ -11,6 +11,7 @@ import useLibraryStore from '../../../stores/library'
 import { fetchItem } from '../item'
 import { ArtistQueryKey } from './keys'
 import { artistAlbumsQuery } from './queries'
+import { LetterCursor } from '../../../types/LetterCursor'
 
 export const useArtist = (artistId: string | undefined | null) => {
 	const api = getApi()
@@ -50,8 +51,15 @@ export const useAlbumArtists = () => {
 		return flattenInfiniteQueryPages(data)
 	}
 
-	return useInfiniteQuery({
-		queryKey: [QueryKeys.InfiniteArtists, isFavorites, sortDescending, library?.musicLibraryId],
+	const queryKey = [
+		QueryKeys.InfiniteArtists,
+		isFavorites,
+		sortDescending,
+		library?.musicLibraryId,
+	]
+
+	const query = useInfiniteQuery({
+		queryKey,
 		queryFn: ({ pageParam, signal }: { pageParam: number; signal?: AbortSignal }) =>
 			fetchArtists(
 				user,
@@ -72,4 +80,23 @@ export const useAlbumArtists = () => {
 			return firstPageParam === 0 ? null : firstPageParam - 1
 		},
 	})
+
+	// Lets the A-Z scroller jump straight to the page containing a given letter
+	const letterCursor: LetterCursor = {
+		queryKey,
+		fetchPage: (page, signal) =>
+			fetchArtists(
+				user,
+				library,
+				page,
+				isFavorites,
+				[ItemSortBy.SortName],
+				[sortDescending ? SortOrder.Descending : SortOrder.Ascending],
+				signal,
+			),
+		countBeforeLetter: (letter, signal) =>
+			fetchArtistsCountBeforeLetter(user, library, letter, isFavorites, signal),
+	}
+
+	return Object.assign(query, { letterCursor })
 }

--- a/src/api/queries/artist/utils/artist.ts
+++ b/src/api/queries/artist/utils/artist.ts
@@ -62,6 +62,54 @@ export function fetchArtists(
 }
 
 /**
+ * Resolves the number of artists sorted before the given letter, so the A-Z
+ * scroller can compute which page that letter falls on without paginating
+ * through every page in between
+ * @param user The user requesting the count
+ * @param library The library to count artists from
+ * @param letter The letter to count artists before
+ * @param isFavorite Whether to only count favorited artists
+ * @param signal Optional AbortSignal to cancel the request
+ * @returns A promise that resolves to the number of artists sorted before the letter
+ */
+export function fetchArtistsCountBeforeLetter(
+	user: JellifyUser | undefined,
+	library: JellifyLibrary | undefined,
+	letter: string,
+	isFavorite: boolean | undefined,
+	signal?: AbortSignal,
+): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const api = getApi()
+
+		if (!api) return reject('No API instance provided')
+		if (!user) return reject('User has not been set')
+		if (!library) return reject('Library has not been set')
+
+		// '#' is the first section in the alphabet selector, so nothing precedes it
+		if (letter === '#') return resolve(0)
+
+		getArtistsApi(api)
+			.getAlbumArtists(
+				{
+					parentId: library.musicLibraryId,
+					userId: user.id,
+					nameLessThan: letter,
+					startIndex: 0,
+					limit: 1,
+					isFavorite: isFavorite,
+					enableTotalRecordCount: true,
+				},
+				{
+					signal,
+				},
+			)
+			.then(({ data }) => resolve(data.TotalRecordCount ?? 0))
+			.catch((error) => reject(error))
+	})
+}
+
+/**
  * Fetches all albums for an artist
  * @param libraryId The ID of the library to fetch albums from
  * @param artist The artist to fetch albums for

--- a/src/api/queries/track/index.ts
+++ b/src/api/queries/track/index.ts
@@ -1,6 +1,6 @@
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
 import { TracksQueryKey } from './keys'
-import fetchTracks from './utils'
+import fetchTracks, { fetchTracksCountBeforeLetter } from './utils'
 import {
 	BaseItemDto,
 	ItemSortBy,
@@ -17,6 +17,7 @@ import { getApi, getUser } from '../../../stores/auth/utils'
 import useLibraryStore from '../../../stores/library'
 import getTrackDto from '../../../utils/mapping/track-extra-payload'
 import { useDownloadedTracks } from 'react-native-nitro-player'
+import { LetterCursor } from '../../../types/LetterCursor'
 
 const useTracks = (
 	sortBy: ItemSortBy,
@@ -59,21 +60,23 @@ const useTracks = (
 		return data.pages.flatMap((page) => page)
 	}
 
-	return useInfiniteQuery({
-		queryKey: TracksQueryKey(
-			isFavorites === true,
-			isDownloaded,
-			isUnplayed === true,
-			finalSortOrder === SortOrder.Descending,
-			library,
-			downloadedTracks?.length,
-			undefined,
-			finalSortBy,
-			finalSortOrder,
-			isDownloaded ? undefined : libraryGenreIds,
-			libraryYearMin,
-			libraryYearMax,
-		),
+	const queryKey = TracksQueryKey(
+		isFavorites === true,
+		isDownloaded,
+		isUnplayed === true,
+		finalSortOrder === SortOrder.Descending,
+		library,
+		downloadedTracks?.length,
+		undefined,
+		finalSortBy,
+		finalSortOrder,
+		isDownloaded ? undefined : libraryGenreIds,
+		libraryYearMin,
+		libraryYearMax,
+	)
+
+	const query = useInfiniteQuery({
+		queryKey,
 		queryFn: ({ pageParam, signal }) => {
 			if (!isDownloaded) {
 				return fetchTracks(
@@ -132,6 +135,44 @@ const useTracks = (
 		},
 		select: selectTracks,
 	})
+
+	// Lets the A-Z scroller jump straight to the page containing a given letter
+	const letterCursor: LetterCursor = {
+		queryKey,
+		fetchPage: (page, signal) =>
+			fetchTracks(
+				api,
+				user,
+				library,
+				page,
+				isFavorites,
+				isUnplayed,
+				finalSortBy,
+				finalSortOrder,
+				undefined,
+				libraryGenreIds,
+				libraryYearMin,
+				libraryYearMax,
+				signal,
+			),
+		countBeforeLetter: (letter, signal) => {
+			if (isDownloaded) return Promise.reject('Downloaded tracks are not paginated')
+			return fetchTracksCountBeforeLetter(
+				api,
+				user,
+				library,
+				letter,
+				isFavorites,
+				isUnplayed,
+				libraryGenreIds,
+				libraryYearMin,
+				libraryYearMax,
+				signal,
+			)
+		},
+	}
+
+	return Object.assign(query, { letterCursor })
 }
 
 export const useArtistTracks = (
@@ -156,18 +197,20 @@ export const useArtistTracks = (
 		})
 	}
 
+	const artistTracksQueryKey = TracksQueryKey(
+		isFavoritesParam === true,
+		false,
+		isUnplayedParam === true,
+		sortOrder === SortOrder.Descending,
+		library,
+		undefined,
+		artistId,
+		sortBy,
+		sortOrder,
+	)
+
 	const artistTracksInfiniteQuery = useInfiniteQuery({
-		queryKey: TracksQueryKey(
-			isFavoritesParam === true,
-			false,
-			isUnplayedParam === true,
-			sortOrder === SortOrder.Descending,
-			library,
-			undefined,
-			artistId,
-			sortBy,
-			sortOrder,
-		),
+		queryKey: artistTracksQueryKey,
 		queryFn: ({ pageParam }) => {
 			return fetchTracks(
 				api,
@@ -188,7 +231,42 @@ export const useArtistTracks = (
 		},
 		select: selectTracks,
 	})
-	return artistTracksInfiniteQuery
+
+	// Lets the A-Z scroller jump straight to the page containing a given letter
+	const letterCursor: LetterCursor = {
+		queryKey: artistTracksQueryKey,
+		fetchPage: (page, signal) =>
+			fetchTracks(
+				api,
+				user,
+				library,
+				page,
+				isFavoritesParam,
+				isUnplayedParam,
+				sortBy,
+				sortOrder,
+				artistId,
+				undefined,
+				undefined,
+				undefined,
+				signal,
+			),
+		countBeforeLetter: (letter, signal) =>
+			fetchTracksCountBeforeLetter(
+				api,
+				user,
+				library,
+				letter,
+				isFavoritesParam,
+				isUnplayedParam,
+				undefined,
+				undefined,
+				undefined,
+				signal,
+			),
+	}
+
+	return Object.assign(artistTracksInfiniteQuery, { letterCursor })
 }
 export default useTracks
 

--- a/src/api/queries/track/utils/index.ts
+++ b/src/api/queries/track/utils/index.ts
@@ -78,6 +78,78 @@ export default function fetchTracks(
 				return resolve(items)
 			})
 			.catch((error) => {
+				return reject(error)
+			})
+	})
+}
+
+/**
+ * Resolves the number of tracks sorted before the given letter, so the A-Z
+ * scroller can compute which page that letter falls on without paginating
+ * through every page in between
+ * @param api The Jellyfin API instance
+ * @param user The user requesting the count
+ * @param library The library to count tracks from
+ * @param letter The letter to count tracks before
+ * @param isFavorite Whether to only count favorited tracks
+ * @param isUnplayed Whether to only count unplayed tracks
+ * @param genreIds Optional genre ID filter
+ * @param yearMin Optional minimum year filter
+ * @param yearMax Optional maximum year filter
+ * @param signal Optional AbortSignal to cancel the request
+ * @returns A promise that resolves to the number of tracks sorted before the letter
+ */
+export function fetchTracksCountBeforeLetter(
+	api: Api | undefined,
+	user: JellifyUser | undefined,
+	library: JellifyLibrary | undefined,
+	letter: string,
+	isFavorite: boolean | undefined,
+	isUnplayed: boolean | undefined,
+	genreIds?: string[],
+	yearMin?: number,
+	yearMax?: number,
+	signal?: AbortSignal,
+): Promise<number> {
+	return new Promise((resolve, reject) => {
+		if (isUndefined(api)) return reject('Client instance not set')
+		if (isUndefined(library)) return reject('Library instance not set')
+		if (isUndefined(user)) return reject('User instance not set')
+
+		// '#' is the first section in the alphabet selector, so nothing precedes it
+		if (letter === '#') return resolve(0)
+
+		const filters: ItemFilter[] = []
+		if (isFavorite === true) {
+			filters.push(ItemFilter.IsFavorite)
+		}
+		if (isUnplayed === true) {
+			filters.push(ItemFilter.IsUnplayed)
+		}
+
+		const yearsParam = buildYearsParam(yearMin, yearMax)
+
+		getItemsApi(api)
+			.getItems(
+				{
+					includeItemTypes: [BaseItemKind.Audio],
+					parentId: library.musicLibraryId,
+					userId: user.id,
+					recursive: true,
+					filters: filters.length > 0 ? filters : undefined,
+					nameLessThan: letter,
+					startIndex: 0,
+					limit: 1,
+					genreIds: genreIds && genreIds.length > 0 ? genreIds : undefined,
+					years: yearsParam,
+					enableTotalRecordCount: true,
+				},
+				{
+					signal,
+				},
+			)
+			.then(({ data }) => resolve(data.TotalRecordCount ?? 0))
+			.catch((error) => {
 				console.error(error)
 				return reject(error)
 			})

--- a/src/components/Albums/component.tsx
+++ b/src/components/Albums/component.tsx
@@ -7,9 +7,12 @@ import { SectionListRef } from '@legendapp/list/section-list'
 import { LibrarySectionListData, LibrarySectionListRenderItemInfo } from '../Global/types'
 import ItemSectionList from '../Global/components/item-section-list'
 import ItemList from '../Global/components/item-list'
+import { LetterCursor } from '../../types/LetterCursor'
 
 interface AlbumsProps {
-	albumsInfiniteQuery: UseInfiniteQueryResult<(BaseItemDto | LibrarySectionListData)[], Error>
+	albumsInfiniteQuery: UseInfiniteQueryResult<(BaseItemDto | LibrarySectionListData)[], Error> & {
+		letterCursor: LetterCursor
+	}
 	sortBy?: ItemSortBy
 	sortDescending?: boolean
 }
@@ -47,7 +50,11 @@ export default function Albums({
 		<ItemSectionList
 			ref={sectionListRef}
 			renderItem={renderItem}
-			query={albumsInfiniteQuery as UseInfiniteQueryResult<LibrarySectionListData[], Error>}
+			query={
+				albumsInfiniteQuery as UseInfiniteQueryResult<LibrarySectionListData[], Error> & {
+					letterCursor: LetterCursor
+				}
+			}
 			sortDescending={sortDescending}
 		/>
 	) : (

--- a/src/components/Artists/component.tsx
+++ b/src/components/Artists/component.tsx
@@ -4,9 +4,12 @@ import { UseInfiniteQueryResult } from '@tanstack/react-query'
 import { SectionListRef } from '@legendapp/list/section-list'
 import { LibrarySectionListData, LibrarySectionListRenderItemInfo } from '../Global/types'
 import ItemSectionList from '../Global/components/item-section-list'
+import { LetterCursor } from '../../types/LetterCursor'
 
 export interface ArtistsProps {
-	artistsInfiniteQuery: UseInfiniteQueryResult<LibrarySectionListData[], Error>
+	artistsInfiniteQuery: UseInfiniteQueryResult<LibrarySectionListData[], Error> & {
+		letterCursor: LetterCursor
+	}
 	sortDescending?: boolean
 }
 

--- a/src/components/Global/components/AZScroller/index.tsx
+++ b/src/components/Global/components/AZScroller/index.tsx
@@ -9,13 +9,14 @@ import { LibrarySectionListData } from '../../types'
 import { SectionListRef } from '@legendapp/list/section-list'
 import onLetterPaginateQuery from './utils'
 import { UseInfiniteQueryResult } from '@tanstack/react-query'
+import { LetterCursor } from '../../../../types/LetterCursor'
 
 const alphabetAtoZ = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 const alphabetZtoA = '#ZYXWVUTSRQPONMLKJIHGFEDCBA'.split('')
 
 interface AZScrollerProps {
 	sectionListRef: RefObject<SectionListRef | null>
-	query: UseInfiniteQueryResult<LibrarySectionListData[], Error>
+	query: UseInfiniteQueryResult<LibrarySectionListData[], Error> & { letterCursor: LetterCursor }
 	alphabet?: string[]
 	reverseOrder?: boolean
 }
@@ -92,12 +93,13 @@ export default function AZScroller({
 
 	const scrollToLetter = (selectedLetter: string) => {
 		if (query.data) {
-			const upperLetters = query.data
-				.map((section) => section.title)
-				.map((letter) => letter.toUpperCase())
-				.sort()
+			// Search the sections in their actual rendered order (not a re-sorted copy),
+			// since that order can be ascending or descending depending on `reverseOrder`
+			const sectionTitles = query.data.map((section) => section.title.toUpperCase())
 
-			const index = upperLetters.findIndex((letter) => letter >= selectedLetter)
+			const index = reverseOrder
+				? sectionTitles.findIndex((letter) => letter <= selectedLetter)
+				: sectionTitles.findIndex((letter) => letter >= selectedLetter)
 
 			if (index !== -1) {
 				sectionListRef.current?.scrollToLocation({
@@ -107,19 +109,6 @@ export default function AZScroller({
 					animated: true,
 				})
 			}
-
-			// else {
-			// 	// fallback: scroll to last section
-			// 	const lastLetter = upperLetters[upperLetters.length - 1]
-			// 	const scrollIndex = artists.indexOf(lastLetter)
-			// 	if (scrollIndex !== -1) {
-			// 		sectionListRef.current?.scrollToIndex({
-			// 			index: scrollIndex,
-			// 			viewPosition: 0.1,
-			// 			animated: true,
-			// 		})
-			// 	}
-			// }
 		}
 	}
 

--- a/src/components/Global/components/AZScroller/utils.ts
+++ b/src/components/Global/components/AZScroller/utils.ts
@@ -1,17 +1,65 @@
-import { UseInfiniteQueryResult } from '@tanstack/react-query'
+import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client'
+import { InfiniteData, UseInfiniteQueryResult } from '@tanstack/react-query'
 import { LibrarySectionListData } from '../../types'
+import { LetterCursor } from '../../../../types/LetterCursor'
+import { ApiLimits, MaxPages } from '../../../../configs/querying/index.config'
+import { queryClient } from '../../../../constants/query-client'
 
+/**
+ * Jumps the given infinite query straight to the page containing `selectedLetter`,
+ * fetching a single page at the resolved cursor instead of paginating through
+ * every page in between.
+ */
 export default async function onLetterPaginateQuery(
 	selectedLetter: string,
-	query: UseInfiniteQueryResult<LibrarySectionListData[], Error>,
+	query: UseInfiniteQueryResult<LibrarySectionListData[], Error> & { letterCursor: LetterCursor },
 ) {
-	do {
-		await query.fetchNextPage()
-	} while (
-		!query.isFetchNextPageError &&
-		!query.isError &&
-		query.hasNextPage &&
-		query.data?.filter((section) => section.title.localeCompare(selectedLetter) === 0)
-			.length === 0
-	)
+	const letter = selectedLetter.toUpperCase()
+
+	const alreadyLoaded = query.data?.some((section) => section.title === letter)
+
+	// Nothing to do if the letter is already loaded, or there's nothing left to fetch
+	if (alreadyLoaded || !query.hasNextPage || query.isError) return
+
+	const { queryKey, fetchPage, countBeforeLetter } = query.letterCursor
+
+	const itemsBeforeLetter = await countBeforeLetter(letter)
+	const page = Math.floor(itemsBeforeLetter / ApiLimits.Library)
+
+	const items = await fetchPage(page)
+
+	queryClient.setQueryData<InfiniteData<BaseItemDto[], number>>(queryKey, (old) => {
+		if (!old) return old
+
+		const existingIndex = old.pageParams.indexOf(page)
+
+		if (existingIndex !== -1) {
+			const pages = [...old.pages]
+			pages[existingIndex] = items
+			return { ...old, pages }
+		}
+
+		// Insert at the position matching this page's place in the overall sequence
+		// (not always at the end), so flattened items stay in the server's sort order
+		// even when letters are jumped to out of sequence
+		const insertAt = old.pageParams.findIndex((existingPage) => existingPage > page)
+		const at = insertAt === -1 ? old.pageParams.length : insertAt
+
+		const pages = [...old.pages.slice(0, at), items, ...old.pages.slice(at)]
+		const pageParams = [...old.pageParams.slice(0, at), page, ...old.pageParams.slice(at)]
+
+		// Mirror react-query's own maxPages trimming so the jump doesn't grow the cache unbounded,
+		// dropping from whichever end is farthest from the page we just inserted
+		if (pages.length > MaxPages.Library) {
+			if (at > pages.length / 2) {
+				pages.shift()
+				pageParams.shift()
+			} else {
+				pages.pop()
+				pageParams.pop()
+			}
+		}
+
+		return { pages, pageParams }
+	})
 }

--- a/src/components/Global/components/item-section-list.tsx
+++ b/src/components/Global/components/item-section-list.tsx
@@ -7,10 +7,11 @@ import { RefreshControl } from 'react-native'
 import { closeAllSwipeableRows } from './SwipeableRow/registery'
 import AZScroller from './AZScroller'
 import ListStickyHeader from '../helpers/list-sticky-header'
+import { LetterCursor } from '../../../types/LetterCursor'
 
 interface ItemSectionListProps {
 	ref: RefObject<SectionListRef | null>
-	query: UseInfiniteQueryResult<LibrarySectionListData[], Error>
+	query: UseInfiniteQueryResult<LibrarySectionListData[], Error> & { letterCursor: LetterCursor }
 	renderItem: (info: LibrarySectionListRenderItemInfo) => JSX.Element
 	sortDescending: boolean | undefined
 }
@@ -54,6 +55,7 @@ export default function ItemSectionList({
 						</Paragraph>
 					</YStack>
 				}
+				recycleItems
 			/>
 
 			<AZScroller query={query} reverseOrder={sortDescending} sectionListRef={ref} />

--- a/src/components/Tracks/component.tsx
+++ b/src/components/Tracks/component.tsx
@@ -11,9 +11,12 @@ import { SectionListRef } from '@legendapp/list/section-list'
 import { useNavigation } from '@react-navigation/native'
 import ItemList from '../Global/components/item-list'
 import ItemSectionList from '../Global/components/item-section-list'
+import { LetterCursor } from '../../types/LetterCursor'
 
 interface TracksProps {
-	tracksInfiniteQuery: UseInfiniteQueryResult<(BaseItemDto | LibrarySectionListData)[], Error>
+	tracksInfiniteQuery: UseInfiniteQueryResult<(BaseItemDto | LibrarySectionListData)[], Error> & {
+		letterCursor: LetterCursor
+	}
 	trackPageParams?: RefObject<Set<string>>
 	showAlphabeticalSelector?: boolean
 	sortBy?: ItemSortBy
@@ -62,7 +65,11 @@ function TracksSectionList({
 	return (
 		<ItemSectionList
 			ref={sectionListRef}
-			query={tracksInfiniteQuery as UseInfiniteQueryResult<LibrarySectionListData[], Error>}
+			query={
+				tracksInfiniteQuery as UseInfiniteQueryResult<LibrarySectionListData[], Error> & {
+					letterCursor: LetterCursor
+				}
+			}
 			renderItem={renderItem}
 			sortDescending={sortDescending}
 		/>

--- a/src/screens/types.d.ts
+++ b/src/screens/types.d.ts
@@ -17,6 +17,7 @@ import TabParamList from './Tabs/types'
 import { PlayerParamList } from './Player/types'
 import LoginStackParamList from './Login/types'
 import { LibrarySectionListData } from '../components/Global/types'
+import { LetterCursor } from '../types/LetterCursor'
 
 export type BaseStackParamList = {
 	Artist: {
@@ -37,7 +38,12 @@ export type BaseStackParamList = {
 	}
 
 	Tracks: {
-		tracksInfiniteQuery: UseInfiniteQueryResult<(BaseItemDto | LibrarySectionListData)[], Error>
+		tracksInfiniteQuery: UseInfiniteQueryResult<
+			(BaseItemDto | LibrarySectionListData)[],
+			Error
+		> & {
+			letterCursor: LetterCursor
+		}
 		showAlphabeticalSelector?: boolean
 	}
 }

--- a/src/types/LetterCursor.ts
+++ b/src/types/LetterCursor.ts
@@ -1,0 +1,26 @@
+import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client'
+import { QueryKey } from '@tanstack/react-query'
+
+/**
+ * Lets the A-Z scroller jump straight to the page containing a given letter
+ * instead of paginating through every page in between.
+ */
+export interface LetterCursor {
+	/**
+	 * The query key of the infinite query this cursor belongs to, so the
+	 * fetched page can be merged directly into that query's cache
+	 */
+	queryKey: QueryKey
+
+	/**
+	 * Fetches a single page (respecting the same page size the infinite query
+	 * uses) at the given page index
+	 */
+	fetchPage: (page: number, signal?: AbortSignal) => Promise<BaseItemDto[]>
+
+	/**
+	 * Resolves the number of items sorted before the given letter, which is
+	 * used to compute which page that letter falls on
+	 */
+	countBeforeLetter: (letter: string, signal?: AbortSignal) => Promise<number>
+}


### PR DESCRIPTION
This pull request adds support for efficient A-Z (letter) navigation in paginated lists of artists, albums, and tracks by introducing a "letter cursor" mechanism to each entity's React Query hook. This allows the A-Z scroller component to jump directly to the page containing a tapped letter, rather than paginating through every page sequentially. The implementation includes new utility functions to quickly count the number of items before a given letter, updated hook return values, and thorough documentation of the pattern.

The most important changes are:

**A-Z Scroller Integration for Infinite Lists:**
- Added a `letterCursor` object to the return value of `useInfiniteQuery` hooks for artists, albums, and tracks (`useAlbumArtists`, `useAlbums`, `useTracks`, and `useArtistTracks`). This object provides methods to fetch a specific page and to count items before a given letter, enabling instant jumps in the A-Z scroller. [[1]](diffhunk://#diff-480841fef1e70fdbb2157f11e3b7923614b53b361ea7243194e967ceb0a48a10R83-R101) [[2]](diffhunk://#diff-6056e1541b5dfe2b692e7bd3cecd67704fd29b700199c6b25091df8e312a1099R95-R125) [[3]](diffhunk://#diff-5967695acd86d1a5a2765fb03ca60ddcebb00b08c47541d2191feb6a3d4c4552R138-R175) [[4]](diffhunk://#diff-5967695acd86d1a5a2765fb03ca60ddcebb00b08c47541d2191feb6a3d4c4552L191-R269)

**New Utility Functions for Counting Items Before a Letter:**
- Implemented `fetchArtistsCountBeforeLetter`, `fetchAlbumsCountBeforeLetter`, and `fetchTracksCountBeforeLetter` utility functions. These use the Jellyfin API with the `nameLessThan` and `enableTotalRecordCount` options to efficiently determine how many items precede a given letter, avoiding unnecessary pagination. [[1]](diffhunk://#diff-cb7b05b37f9de3a30162b0dbc6c6967f6665e4f503feac61e7d599c5fe1d0165R64-R111) [[2]](diffhunk://#diff-e4b2304f1e5ea712b219859421e16e452a15cf210b961ec7f5e3eef8af032806R68-R124) [[3]](diffhunk://#diff-b226100a820ad5cc0ce6ab89be1554c7cd61a67fa373b5aaba6b804ad9afcf26R80-R151)

**Query Hook Refactoring:**
- Refactored query hooks to extract and reuse `queryKey` arrays, facilitating their use in the new `letterCursor` objects and improving code clarity. [[1]](diffhunk://#diff-6056e1541b5dfe2b692e7bd3cecd67704fd29b700199c6b25091df8e312a1099L59-R71) [[2]](diffhunk://#diff-480841fef1e70fdbb2157f11e3b7923614b53b361ea7243194e967ceb0a48a10L53-R62) [[3]](diffhunk://#diff-5967695acd86d1a5a2765fb03ca60ddcebb00b08c47541d2191feb6a3d4c4552L62-R63) [[4]](diffhunk://#diff-5967695acd86d1a5a2765fb03ca60ddcebb00b08c47541d2191feb6a3d4c4552L159-R200)

**Documentation:**
- Added a comprehensive README (`src/api/queries/README.md`) describing the folder structure, infinite query design, and the new letter cursor mechanism, including usage details and rationale.

**Type and Import Updates:**
- Updated imports and type definitions to include the new `LetterCursor` type and utility functions where needed in the query hooks. [[1]](diffhunk://#diff-6056e1541b5dfe2b692e7bd3cecd67704fd29b700199c6b25091df8e312a1099R17) [[2]](diffhunk://#diff-480841fef1e70fdbb2157f11e3b7923614b53b361ea7243194e967ceb0a48a10R14) [[3]](diffhunk://#diff-5967695acd86d1a5a2765fb03ca60ddcebb00b08c47541d2191feb6a3d4c4552R20)

These changes collectively improve the user experience for navigating large music libraries by making A-Z jumps instantaneous and memory-efficient.